### PR TITLE
sets LC_ALL var

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+ENV['LC_ALL'] = "en_US.utf8"
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 
 include_recipe "postgresql::client"


### PR DESCRIPTION
the lack of a proper locale set breaks
postgres installation (default database cluster
is not created).

There are some discussions on the issue here:
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=510658

I got this issue running chef-client on linode on a 11.10 ubuntu server (64bits).

You might want to extend my hack to make it configurable in some way, or you can sugest me how to do it :)
