### PR TITLE
COOK-1011 - install packages on runtime not on compile time

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -34,11 +34,7 @@ when "redhat","centos","scientific"
 end
 
 pg_packages.each do |pg_pack|
-  package pg_pack do
-    action :nothing
-  end.run_action(:install)
+  package pg_pack 
 end
 
-gem_package "pg" do
-  action :nothing
-end.run_action(:install)
+gem_package "pg" 


### PR DESCRIPTION
installing client packages on runtime brakes possibility to invoke apt-get update beforehand
