### PR TITLE
Only use a versioned service_name on Ubuntu 10.04 and under if we're using PostgreSQL 8.4 and under

### DIFF
--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -34,7 +34,7 @@ service "postgresql" do
   case node['platform']
   when "ubuntu"
     case
-    when node['platform_version'].to_f <= 10.04
+    when node['platform_version'].to_f <= 10.04 && node['postgresql']['version'].to_f <= 8.4
       service_name "postgresql-#{node['postgresql']['version']}"
     else
       service_name "postgresql"


### PR DESCRIPTION
This ensures that if we're using a backported package of PostgreSQL 9 upwards that the service is named correctly.
