### PR TITLE
COOK-1391 - Postgresql cookbook has issues installing the pg gem

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -39,6 +39,4 @@ pg_packages.each do |pg_pack|
   end.run_action(:install)
 end
 
-chef_gem "pg" do
-  action :nothing
-end.run_action(:install)
+chef_gem "pg"


### PR DESCRIPTION
This change just replaces the gem_package resource with chef_gem.
