### PR TITLE
[CHEF-3283] Fixes locale problems in Ubuntu 12.04 that prevents installation of postgresql

### DIFF
--- a/recipes/fix_locale.rb
+++ b/recipes/fix_locale.rb
@@ -1,0 +1,7 @@
+execute :fix_locale do
+  command 'export LANGUAGE=en_US.UTF-8'
+  command 'export LANG=en_US.UTF-8'
+  command 'export LC_ALL=en_US.UTF-8'
+  command 'locale-gen en_US.UTF-8'
+  command 'sudo dpkg-reconfigure locales'
+end

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -20,6 +20,7 @@
 #
 
 include_recipe "postgresql::client"
+include_recipe "postgresql::fix_locale"
 
 case node[:postgresql][:version]
 when "8.3"


### PR DESCRIPTION
https://tickets.opscode.com/browse/CHEF-3283

I'm applying the fix as shown here

http://serverfault.com/questions/384324/postgres-used-in-ubuntu-12-04

It may be related to pull request #1

Applying the recipe before postgresql installation worked for me on a vanilla rackspace Ubuntu 12 instance. Otherwise the default recipe always fail as illustrated in the ServerFault page.
