### PR TITLE
[COOK-1462] Add :listen_addresses attribute to cookbook templates.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,3 +73,5 @@ else
   default[:postgresql][:version] = "8.4"
   set[:postgresql][:dir]         = "/etc/postgresql/#{node[:postgresql][:version]}/main"
 end
+
+default[:postgresql][:listen_addresses] = "localhost"

--- a/templates/default/debian.postgresql.conf.erb
+++ b/templates/default/debian.postgresql.conf.erb
@@ -53,7 +53,7 @@ external_pid_file = '/var/run/postgresql/<%= node.postgresql.version -%>-main.pi
 
 # - Connection Settings -
 
-#listen_addresses = 'localhost'		# what IP address(es) to listen on;
+listen_addresses = '<%= node.postgresql.listen_addresses -%>'		# what IP address(es) to listen on;
 					# comma-separated list of addresses;
 					# defaults to 'localhost', '*' = all
 					# (change requires restart)

--- a/templates/default/redhat.postgresql.conf.erb
+++ b/templates/default/redhat.postgresql.conf.erb
@@ -56,7 +56,7 @@
 
 # - Connection Settings -
 
-#listen_addresses = 'localhost'         # what IP address(es) to listen on;
+listen_addresses = '<%= node.postgresql.listen_addresses -%>'         # what IP address(es) to listen on;
                                         # comma-separated list of addresses;
                                         # defaults to 'localhost', '*' = all
                                         # (change requires restart)


### PR DESCRIPTION
**Currently being tracked as [COOK-1462](http://tickets.opscode.com/browse/COOK-1462)**

> Currently the postgresql cookbook will only listen on `"localhost"` for database connections which makes this a no-go when running a dedicated/standalone/replicating/slave instance.
> 
> While it's debatable whether or not `"localhost"` is the best default value for this attribute it appears to be PostgreSQL's configuration default, so in the interests of cookbook backwards compatibility this seems a reasonable value.
