### PR TITLE
[COOK-1474] Add :client_authentication attribute to pg_hba.conf.erb.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,3 +73,5 @@ else
   default[:postgresql][:version] = "8.4"
   set[:postgresql][:dir]         = "/etc/postgresql/#{node[:postgresql][:version]}/main"
 end
+
+default[:postgresql][:client_authentication] = []

--- a/templates/default/pg_hba.conf.erb
+++ b/templates/default/pg_hba.conf.erb
@@ -59,7 +59,13 @@
 # or via the -i or -h command line switches.
 #
 
-
+<% node[:postgresql][:client_authentication].each do |hash| -%>
+  <% if hash['type'] == 'local' -%>
+<%= "#{hash['type']} #{hash['database']} #{hash['user']} #{hash['method']} #{hash['options']}" %>
+  <% else -%>
+<%= "#{hash['type']} #{hash['database']} #{hash['user']} #{hash['cidr']} #{hash['method']} #{hash['options']}" %>
+  <% end -%>
+<% end -%>
 
 
 # DO NOT DISABLE!


### PR DESCRIPTION
**Currently being tracked as [COOK-1474](http://tickets.opscode.com/browse/COOK-1474)**

> Currently the postgresql cookbook will only accept client connections from localhost which makes this a no-go when running a dedicated/standalone/replicating/slave instance.
