### PR TITLE
Ensure postgres directory is created

### DIFF
--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -55,6 +55,12 @@ service "postgresql" do
   action :nothing
 end
 
+directory node[:postgresql][:dir] do
+  recursive true
+  owner "postgres"
+  group "postgres"
+end
+
 template "#{node[:postgresql][:dir]}/postgresql.conf" do
   source "debian.postgresql.conf.erb"
   owner "postgres"

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -53,6 +53,12 @@ service "postgresql" do
   action [:enable, :start]
 end
 
+directory node[:postgresql][:dir] do
+  recursive true
+  owner "postgres"
+  group "postgres"
+end
+
 template "#{node[:postgresql][:dir]}/postgresql.conf" do
   source "redhat.postgresql.conf.erb"
   owner "postgres"


### PR DESCRIPTION
Without this the server is likely left in a state where it cant create the configuration file as the directory doesn't exist yet.
