### PR TITLE
COOK-1778 Externalize port configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,3 +101,4 @@ else
 end
 
 default['postgresql']['listen_addresses'] = "localhost"
+default['postgresql']['port'] = 5432

--- a/templates/default/debian.postgresql.conf.erb
+++ b/templates/default/debian.postgresql.conf.erb
@@ -57,7 +57,7 @@ listen_addresses = '<%= node.postgresql.listen_addresses -%>'		# what IP address
 					# comma-separated list of addresses;
 					# defaults to 'localhost', '*' = all
 					# (change requires restart)
-port = 5432				# (change requires restart)
+port = <%= node.postgresql.port %>				# (change requires restart)
 max_connections = 100			# (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per 
 # connection slot, plus lock space (see max_locks_per_transaction).  You might

--- a/templates/default/redhat.postgresql.conf.erb
+++ b/templates/default/redhat.postgresql.conf.erb
@@ -60,7 +60,7 @@ listen_addresses = '<%= node.postgresql.listen_addresses -%>'         # what IP 
                                         # comma-separated list of addresses;
                                         # defaults to 'localhost', '*' = all
                                         # (change requires restart)
-#port = 5432                            # (change requires restart)
+port = <%= node.postgresql.port %>      # (change requires restart)
 max_connections = 100                   # (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per 
 # connection slot, plus lock space (see max_locks_per_transaction).


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1778

This helps changing the port to be used for postgresql
