### PR TITLE
COOK-1779 Don't run apt-get update and others if pg already installed

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -18,19 +18,23 @@
 # limitations under the License.
 #
 
-execute "apt-get update" do
-  ignore_failure true
-  action :nothing
-end.run_action(:run) if node['platform_family'] == "debian"
+begin
+  require 'pg'
+rescue LoadError
+  execute "apt-get update" do
+    ignore_failure true
+    action :nothing
+  end.run_action(:run) if node['platform_family'] == "debian"
 
-node.set['build_essential']['compiletime'] = true
-include_recipe "build-essential"
-include_recipe "postgresql::client"
+  node.set['build_essential']['compiletime'] = true
+  include_recipe "build-essential"
+  include_recipe "postgresql::client"
 
-node['postgresql']['client']['packages'].each do |pg_pack|
+  node['postgresql']['client']['packages'].each do |pg_pack|
 
-  resources("package[#{pg_pack}]").run_action(:install)
+    resources("package[#{pg_pack}]").run_action(:install)
 
+  end
+
+  chef_gem "pg"
 end
-
-chef_gem "pg"


### PR DESCRIPTION
If pg gem is already installed, then, avoid running in compile time
the resources that includes, like apt-get update.

http://tickets.opscode.com/browse/COOK-1779
