### PR TITLE
COOK-1780 Adds attribute to configure pg_hba entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ The following attributes are set based on the platform, see the
 * `node['postgresql']['server']['packages']` - An array of package names
   that should be installed on "server" systems.
 
+The following attributes are set for all platforms, see the
+`attributes/default.rb` file for default values.
+
+ * `node['postgresql']['hba_conf']` - An array of the hba_conf entries
+ to include. Each entry is a map with keys: `:type`,`:database`,
+ `:user`, `:address`, `:method`.
+ For example `{:type => 'host' , :database => 'all', :user => 'all',
+ :address => '127.0.0.1/32' , :method => 'md5'}`
 
 The following attributes are generated in
 `recipe[postgresql::server]`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,3 +101,8 @@ else
 end
 
 default['postgresql']['listen_addresses'] = "localhost"
+default['postgresql']['hba_conf'] = [
+  {:type => 'local', :database => 'all', :user => 'all', :method => 'ident'},
+  {:type => 'host' , :database => 'all', :user => 'all', :address => '127.0.0.1/32' , :method => 'md5'},
+  {:type => 'host' , :database => 'all', :user => 'all', :address => '::1/128' , :method => 'md5'}
+]

--- a/templates/default/pg_hba.conf.erb
+++ b/templates/default/pg_hba.conf.erb
@@ -75,9 +75,6 @@ local   all         postgres                          ident
 
 # TYPE  DATABASE    USER        CIDR-ADDRESS          METHOD
 
-# "local" is for Unix domain socket connections only
-local   all         all                               ident
-# IPv4 local connections:
-host    all         all         127.0.0.1/32          md5
-# IPv6 local connections:
-host    all         all         ::1/128               md5
+<% node.postgresql.hba_conf.each do |line| -%>
+<%= sprintf("%-8s%-12s%-12s%-22s%s", line[:type], line.fetch(:database,'all'), line.fetch(:user,'all'), line.fetch(:address,''), line[:method])%>
+<% end -%>


### PR DESCRIPTION
Adds a new attribute that lets the user configure
different entries for the pg_hba file.
