### PR TITLE
Fix for postgresql.conf random line ordering [COOK-1961]

### DIFF
--- a/templates/default/postgresql.conf.erb
+++ b/templates/default/postgresql.conf.erb
@@ -3,7 +3,7 @@
 # Please refer to the PostgreSQL documentation for details on
 # configuration settings.
 
-<% node['postgresql']['config'].each do |key, value| %>
+<% node['postgresql']['config'].sort.each do |key, value| %>
 <% next if value.nil? -%>
 <%= key %> = <%=
   case value


### PR DESCRIPTION
Just sort configuration keys before emitting.  See [COOK-1961](http://tickets.opscode.com/browse/COOK-1961)
