### PR TITLE
[COOK-2041] - Updated attrib.rb for suse

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -106,7 +106,7 @@ when "suse"
   end
 
   default['postgresql']['dir'] = "/var/lib/pgsql/data"
-  default['postgresql']['client']['packages'] = %w{postgresql-client libpq-dev}
+  default['postgresql']['client']['packages'] = %w{postgresql-devel}
   default['postgresql']['server']['packages'] = %w{postgresql-server}
   default['postgresql']['server']['service_name'] = "postgresql"
 
@@ -146,7 +146,7 @@ when 'debian'
   default['postgresql']['config']['datestyle'] = 'iso, mdy'
   default['postgresql']['config']['default_text_search_config'] = 'pg_catalog.english'
   default['postgresql']['config']['ssl'] = true
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'suse'
   default['postgresql']['config']['listen_addresses'] = 'localhost'
   default['postgresql']['config']['max_connections'] = 100
   default['postgresql']['config']['shared_buffers'] = '32MB'


### PR DESCRIPTION
Some minor corrections to get openSuSE working again with the postgresql cookbook.

The changes involved:
- Correct client package for openSuSE (postgresql-devel)
- Associating suse with the configuration parameters established for fedora and rhel.
