### PR TITLE
[COOK-2231] Fix support for postgresql 9.x in server_redhat recipe

### DIFF
--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -44,10 +44,8 @@ node['postgresql']['server']['packages'].each do |pg_pack|
 
 end
 
-if node['postgresql']['version'].to_f < 9.0
-  execute "/sbin/service #{node['postgresql']['server']['service_name']} initdb" do
-    not_if { ::FileTest.exist?(File.join(node['postgresql']['dir'], "PG_VERSION")) }
-  end
+execute "/sbin/service #{node['postgresql']['server']['service_name']} initdb" do
+  not_if { ::FileTest.exist?(File.join(node['postgresql']['dir'], "PG_VERSION")) }
 end
 
 service "postgresql" do


### PR DESCRIPTION
This was originally lumped into COOK-2051, so I agreed to break it out as a separate ticket.
I needed to make two changes to get the server_redhat recipe to work. These both seem to be inadvertent coding mistakes with commits in early November 2012. See my commits (or the COOK-2231 ticket) for details.
