### PR TITLE
[COOK-2176] Set a default value for node['postgresql']['password'].

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -179,4 +179,6 @@ default['postgresql']['pg_hba'] = [
   {:type => 'host', :db => 'all', :user => 'all', :addr => '::1/128', :method => 'md5'}
 ]
 
+default['postgresql']['password'] = Hash.new
+
 default['postgresql']['enable_pitti_ppa'] = false


### PR DESCRIPTION
Set at least the node['postgresql']['password'] as an empty Hash by default to avoid errors.
