### PR TITLE
[COOK-2383] As of Amazon Linux 2012.03 postgresql 9.0 is the default.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -80,8 +80,14 @@ when "fedora"
 
 when "amazon"
 
-  default['postgresql']['version'] = "8.4"
-  default['postgresql']['dir'] = "/var/lib/pgsql/data"
+  if node['platform_version'].to_f >= 2012.03
+    default['postgresql']['version'] = "9.0"
+    default['postgresql']['dir'] = "/var/lib/pgsql9/data"
+  else
+    default['postgresql']['version'] = "8.4"
+    default['postgresql']['dir'] = "/var/lib/pgsql/data"
+  end
+
   default['postgresql']['client']['packages'] = %w{postgresql-devel}
   default['postgresql']['server']['packages'] = %w{postgresql-server}
   default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2383

Updated version number and data directory with appropriate values.
