### PR TITLE
[COOK-2435] Fix foodcritic errors.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -20,4 +20,6 @@ end
   supports el, ">= 6.0"
 end
 
+depends "apt"
+depends "build-essential"
 depends "openssl"

--- a/recipes/yum_pgdg_postgresql.rb
+++ b/recipes/yum_pgdg_postgresql.rb
@@ -47,13 +47,13 @@ repo_rpm_package = repo_rpm_filename.split(/-/,3)[0..1].join('-')
 
 # Download the PGDG repository RPM as a local file
 remote_file "#{Chef::Config[:file_cache_path]}/#{repo_rpm_filename}" do
-  source "#{repo_rpm_url}"
+  source repo_rpm_url
   mode "0644"
 end
 
 # Install the PGDG repository RPM from the local file
 # E.g., /etc/yum.repos.d/pgdg-91-centos.repo
-package "#{repo_rpm_package}" do
+package repo_rpm_package do
   provider Chef::Provider::Package::Rpm
   source "#{Chef::Config[:file_cache_path]}/#{repo_rpm_filename}"
   action :install


### PR DESCRIPTION
FC002: Avoid string interpolation where not required: ./recipes/yum_pgdg_postgresql.rb:50
FC002: Avoid string interpolation where not required: ./recipes/yum_pgdg_postgresql.rb:56
FC007: Ensure recipe dependencies are reflected in cookbook metadata: ./recipes/ppa_pitti_postgresql.rb:1
FC007: Ensure recipe dependencies are reflected in cookbook metadata: ./recipes/ruby.rb:30

I left this one alone:

FC024: Consider adding platform equivalents: ./attributes/default.rb:90

because I'm pretty sure Amazon Linux does things different and that's why there's a separate clause for it.
