### PR TITLE
Update pg_hba example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ the array must be symbols. Each hash will be written as a line in
 `pg_hba.conf`. For example, this entry from
 `node['postgresql']['pg_hba']`:
 
-    {:comment => '# Optional comment',
-    :type => 'local', :db => 'all', :user => 'postgres', :addr => nil, :method => 'md5'}
+    [{:comment => '# Optional comment',
+     :type => 'local', :db => 'all', :user => 'postgres', :addr => nil, :method => 'md5'}]
 
 Will result in the following line in `pg_hba.conf`:
 


### PR DESCRIPTION
The example for the pg_hba.conf lines is a little misleading as it does not show the values as an array of hashes. This is a simple fix to the README.md to help clarify this information.
