### PR TITLE
[COOK-3553] Removed apt-get update

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -21,11 +21,7 @@
 begin
   require 'pg'
 rescue LoadError
-  execute "apt-get update" do
-    ignore_failure true
-    action :nothing
-  end.run_action(:run) if node['platform_family'] == "debian"
-
+  
   node.set['build_essential']['compiletime'] = true
   include_recipe "build-essential"
   include_recipe "postgresql::client"


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3553

It should not be handled by this cookbook. Especially without last run check. Let other cookbook (like apt) decide when it's time to run apt-get update.
