### PR TITLE
[COOK-2797] extensions containing '-' fail

### DIFF
--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -32,7 +32,7 @@ if (node['postgresql']['contrib'].attribute?('extensions'))
     bash "install-#{pg_ext}-extension" do
       user 'postgres'
       code <<-EOH
-        echo "CREATE EXTENSION IF NOT EXISTS #{pg_ext};" | psql -d template1
+        echo 'CREATE EXTENSION IF NOT EXISTS "#{pg_ext}";' | psql -d template1
       EOH
       action :run
     end


### PR DESCRIPTION
Bash resource in contrib recipe fails to load the uuid-ossp contrib
extension due to improperly quoted echo statement. Adding the proper
quotes fixes the issue.
