### PR TITLE
Renamed example configuration to listen_addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ generated from attributes. Each key in `node['postgresql']['config']`
 is a postgresql configuration directive, and will be rendered in the
 config file. For example, the attribute:
 
-    node['postgresql']['config']['listen_address'] = 'localhost'
+    node['postgresql']['config']['listen_addresses'] = 'localhost'
 
 Will result in the following line in the `postgresql.conf` file:
 
-    listen_address = 'localhost'
+    listen_addresses = 'localhost'
 
 The attributes file contains default values for Debian and RHEL
 platform families (per the `node['platform_family']`). These defaults


### PR DESCRIPTION
The example used the configuration option "listen_address" which isn't correct. The correct configuration option is "listen_addresses". It doesn't affect the point the config is trying to make, but it is misleading for someone searching for that particular option.
