### PR TITLE
[COOK-2954] Support Installing non-standard versions on CentOS 6

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,7 +92,7 @@ when "redhat", "centos", "scientific", "oracle"
   default['postgresql']['version'] = "8.4"
   default['postgresql']['dir'] = "/var/lib/pgsql/data"
 
-  if node['platform_version'].to_f >= 6.0
+  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'] == '8.4'
     default['postgresql']['client']['packages'] = %w{postgresql-devel}
     default['postgresql']['server']['packages'] = %w{postgresql-server}
     default['postgresql']['contrib']['packages'] = %w{postgresql-contrib}
@@ -101,7 +101,14 @@ when "redhat", "centos", "scientific", "oracle"
     default['postgresql']['server']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-server"]
     default['postgresql']['contrib']['packages'] = ["postgresql#{node['postgresql']['version'].split('.').join}-contrib"]
   end
-  default['postgresql']['server']['service_name'] = "postgresql"
+
+  if node['platform_version'].to_f >= 6.0 && node['postgresql']['version'] != '8.4'
+     default['postgresql']['dir'] = "/var/lib/pgsql/#{node['postgresql']['version']}/data"
+     default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
+  else
+    default['postgresql']['dir'] = "/var/lib/pgsql/data"
+    default['postgresql']['server']['service_name'] = "postgresql"
+  end
 
 when "suse"
 


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-2954

The old package selection, service name and data directory
logic was such that it would always install the basic
postgresql packages (8.4) on CentOS 6 even if the node's
postgresql version was set to be different to the CentOS 6
default version and the pgdg repository was enabled.

This commit adds extra logic for this new scenario without
(I believe) affecting any of the previous logic.
