### PR TITLE
Send :reload to service[postgresql] on postgresql.conf changes

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -62,7 +62,7 @@ template "#{node['postgresql']['dir']}/postgresql.conf" do
   owner "postgres"
   group "postgres"
   mode 0600
-  notifies :restart, 'service[postgresql]', :immediately
+  notifies :reload, 'service[postgresql]', :immediately
 end
 
 template "#{node['postgresql']['dir']}/pg_hba.conf" do


### PR DESCRIPTION
The current code sends :restart, which is disruptive. It is also not
necessary in many situations (like changes to the `log_*` config attributes).
Sending :reload means that some config changes that require :restart won't
take effect automatically, but I think that's a safer default than the
disruptive restart-all-the-time strategy.

Callers that want the old behavior can patch the resource:

``` ruby
pgconf = resources("#{node['postgresql']['dir']}/postgresql.conf") 
pgconf.notifies :restart, 'service[postgresql]', :immediately
```
