### PR TITLE
COOK-2939 Set data directory and port correctly for init script

### DIFF
--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -38,10 +38,23 @@ user "postgres" do
   supports :manage_home => false
 end
 
+directory node['postgresql']['dir'] do
+  owner "postgres"
+  group "postgres"
+  recursive true
+  action :create
+end
+
 node['postgresql']['server']['packages'].each do |pg_pack|
 
   package pg_pack
 
+end
+
+template "/etc/sysconfig/pgsql/#{node['postgresql']['server']['service_name']}" do
+  source "pgsql.sysconfig.erb"
+  mode "0644"
+  notifies :restart, "service[postgresql]", :delayed
 end
 
 unless platform_family?("suse")

--- a/templates/default/pgsql.sysconfig.erb
+++ b/templates/default/pgsql.sysconfig.erb
@@ -1,0 +1,4 @@
+PGDATA=<%= node['postgresql']['dir'] %>
+<% if node['postgresql']['config'].attribute?("port") -%>
+PGPORT=<%= node['postgresql']['config']['port'] %>
+<% end -%>


### PR DESCRIPTION
Setting node[:postgresql][:dir] currently has initdb creating the
database in /var/lib/pgsql/data instead of the desired directory.
Fix this by creating /etc/sysconfig file for the service which sets
PGDATA so the init script can pick it up. Also set PGPORT if
node[:postgresql][:config][:port] is set.

This also creates the node[:postgreql][:dir] owned by postgres:postgres.
