### PR TITLE
Limit local auth override for postgres user only.

### DIFF
--- a/templates/default/pg_hba.conf.erb
+++ b/templates/default/pg_hba.conf.erb
@@ -14,9 +14,9 @@
 
 # "local" is for Unix domain socket connections only
 <% if node['postgresql']['version'].to_f < 9.1 -%>
-local   all             all                                     ident
+local   all             postgres                                ident
 <% elsif node['postgresql']['version'].to_f >= 9.1 -%>
-local   all             all                                     peer
+local   all             postgres                                peer
 <% end -%>
 
 ###########


### PR DESCRIPTION
The existing hardcoded pg_hba authorization record is to compensate for the
recipe requiring postgres's user-password (which is unknown). 

As is, _any_ user is subject to the ident/peer authentication if connecting to
postgres locally. Instead, the permissions can be safely reduced to just the
postgres user.
