### PR TITLE
[COOK-3552] Not necessarily wrong, but somehow misleading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ generated from attributes. Each key in `node['postgresql']['config']`
 is a postgresql configuration directive, and will be rendered in the
 config file. For example, the attribute:
 
-    node['postgresql']['config']['listen_address'] = 'localhost'
+    node['postgresql']['config']['listen_addresses'] = 'localhost'
 
 Will result in the following line in the `postgresql.conf` file:
 
-    listen_address = 'localhost'
+    listen_addresses = 'localhost'
 
 The attributes file contains default values for Debian and RHEL
 platform families (per the `node['platform_family']`). These defaults


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3552

Technically there is nothing wrong with this statement since 
node['postgresql']['config']['listen_address'] = 'localhost' 
will literally write
listen_address = 'localhost'
in the postgresql.conf file, that being said it is slightly misleading since the correct value is "listen_addresses" and not "listen_address", so somebody copy/pastying could get erroneous data.
