### PR TITLE
[COOK-3566] Give the user's rules more priority than the default ones in pg_hba

### DIFF
--- a/templates/default/pg_hba.conf.erb
+++ b/templates/default/pg_hba.conf.erb
@@ -12,13 +12,6 @@
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 <% end -%>
 
-# "local" is for Unix domain socket connections only
-<% if node['postgresql']['version'].to_f < 9.1 -%>
-local   all             all                                     ident
-<% elsif node['postgresql']['version'].to_f >= 9.1 -%>
-local   all             all                                     peer
-<% end -%>
-
 ###########
 # Other authentication configurations taken from chef node defaults:
 ###########
@@ -33,3 +26,10 @@ local   all             all                                     peer
 <%= auth[:type].ljust(7) %> <%= auth[:db].ljust(15) %> <%= auth[:user].ljust(15) %>                         <%= auth[:method] %>
 <%   end %>
 <% end %>
+
+# "local" is for Unix domain socket connections only
+<% if node['postgresql']['version'].to_f < 9.1 -%>
+local   all             all                                     ident
+<% elsif node['postgresql']['version'].to_f >= 9.1 -%>
+local   all             all                                     peer
+<% end -%>


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3566

The priority of the `pg_hba` entries is defined by their position in the file. The sooner they appear, the more priority it has.

The default `local` entry that uses the `ident` auth method has more priority than the node rules, because it appears before. This is problematic because the rule is pretty generic, it applies to all users and all databases. That means the user can't define a more specific rule, for example:

```
local    database    username                                 md5
```

A rule like this would give access by socket to a `username` user to the `database` db using a password. But it won't work since the `ident` default rule appears before in the file.

This pull request changes that, putting the user's rules before the default ones.
