### PR TITLE
[COOK-3427] Immediate restarts on config files break the ability to provide ssl certs in a wrapper cookbook

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -62,7 +62,7 @@ template "#{node['postgresql']['dir']}/postgresql.conf" do
   owner "postgres"
   group "postgres"
   mode 0600
-  notifies :reload, 'service[postgresql]', :immediately
+  notifies :reload, 'service[postgresql]', :delayed
 end
 
 template "#{node['postgresql']['dir']}/pg_hba.conf" do
@@ -70,7 +70,7 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   owner "postgres"
   group "postgres"
   mode 00600
-  notifies :reload, 'service[postgresql]', :immediately
+  notifies :reload, 'service[postgresql]', :delayed
 end
 
 # NOTE: Consider two facts before modifying "assign-postgres-password":


### PR DESCRIPTION
There is more detail in the JIRA ticket here [1] but the TLDR is that if you create the data_directory and the ssl certs in a wrapper cookbook before running "include_recipe 'postgresql::server'" on ubuntu-12.04 the postinst on the debian package won't set everything up that the cookbook assumes it's setting up. If you try to do it after the include_recipe  then the :immediate restarts inside the postgresql::server cookbook kill the chef run with an exception because ssl is on but the certs haven't been provided yet.

Delayed lets you provide additional configuration before postgresql is started up.

[1] http://tickets.opscode.com/browse/COOK-3427
