### PR TITLE
COOK-3490 Fixes pg gem install for v9.2 on RHEL 6

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -86,7 +86,7 @@ EOS
     end
 
     lib_builder = execute 'generate pg gem Makefile' do
-      command "#{RbConfig.ruby} extconf.rb"
+      command "#{RbConfig.ruby} extconf.rb --with-pg-config=/usr/pgsql-#{node['postgresql']['version']}/bin/pg_config"
       cwd ext_dir
       action :nothing
     end


### PR DESCRIPTION
I've not been able to test (yet) whether this works in other
environments. I imagine that the issue is not restricted to postgresql
9.2 but that is the only version I have tested. It definitely works for
my environment and seems to be in the spirit of the existing code.
