### PR TITLE
[COOK-3526] support the case where chef has already started a service but then it has been stopped out-of-band

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -73,6 +73,20 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   notifies :reload, 'service[postgresql]', :immediately
 end
 
+# ensure the service is running
+# (if it has been stopped out-of-band and the above up-to-date,
+# then the assign-postgres-password command below will fail)
+service "postgresql" do
+  action :start
+end
+
+# needed because the above fails if service is stopped out of band
+# see http://serverfault.com/questions/534498/how-to-ensure-a-service-is-running-using-chef
+execute "force-start-postgresql" do
+  command "service postgresql start || /etc/init.d/postgresql start"
+  action :run
+end
+
 # NOTE: Consider two facts before modifying "assign-postgres-password":
 # (1) Passing the "ALTER ROLE ..." through the psql command only works
 #     if passwordless authorization was configured for local connections.


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3526

if a user stops postgres at the machine, running the server recipe susequently fails -- it does not detect that the service is running (on standard opscode ubuntu vagrant box, using Chef 11.6)

note - this contains a "start the service via the shell" anti-pattern.  there may be a better way.  see the question at http://serverfault.com/questions/534498/how-to-ensure-a-service-is-running-using-chef
