### PR TITLE
[COOK-3490] Postgresql::ruby fails with postgresql 9.2 on RHEL & CentOS 6.4

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -86,7 +86,12 @@ EOS
     end
 
     lib_builder = execute 'generate pg gem Makefile' do
-      command "#{RbConfig.ruby} extconf.rb"
+      # [COOK-3490] pg gem install requires full path on RHEL
+      if node['platform_family'] == 'rhel'
+        command "#{RbConfig.ruby} extconf.rb --with-pg-config=/usr/pgsql-#{node['postgresql']['version']}/bin/pg_config"
+      else
+        command "#{RbConfig.ruby} extconf.rb"
+      end
       cwd ext_dir
       action :nothing
     end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3490
