### PR TITLE
Give more priority to the chef custom authentication configs

### DIFF
--- a/templates/default/pg_hba.conf.erb
+++ b/templates/default/pg_hba.conf.erb
@@ -12,13 +12,6 @@
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 <% end -%>
 
-# "local" is for Unix domain socket connections only
-<% if node['postgresql']['version'].to_f < 9.1 -%>
-local   all             all                                     ident
-<% elsif node['postgresql']['version'].to_f >= 9.1 -%>
-local   all             all                                     peer
-<% end -%>
-
 ###########
 # Other authentication configurations taken from chef node defaults:
 ###########
@@ -33,3 +26,11 @@ local   all             all                                     peer
 <%= auth[:type].ljust(7) %> <%= auth[:db].ljust(15) %> <%= auth[:user].ljust(15) %>                         <%= auth[:method] %>
 <%   end %>
 <% end %>
+
+# "local" is for Unix domain socket connections only
+<% if node['postgresql']['version'].to_f < 9.1 -%>
+local   all             all                                     ident
+<% elsif node['postgresql']['version'].to_f >= 9.1 -%>
+local   all             all                                     peer
+<% end -%>
+


### PR DESCRIPTION
Configurations priorities of the `pg_hba.conf` are order sensitive.

The following line is added by default though the chef template:

```
local   all             all                                     peer
```

The problem is: I'm trying to add my custom config (below) and the default one is taking the priority (my conf has no effect).

```
local   all             postgres                                trust
```

To make my custom config priorities I changed the config blocks order.
