### PR TITLE
[COOK-3756] Change postgresql.conf mode from 0600 to 0644

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -61,7 +61,7 @@ template "#{node['postgresql']['dir']}/postgresql.conf" do
   source "postgresql.conf.erb"
   owner "postgres"
   group "postgres"
-  mode 0600
+  mode 0644
   notifies :reload, 'service[postgresql]', :immediately
 end
 


### PR DESCRIPTION
0600 break "pg_wrapper".

If the user isn't root or postres, it can't check if cluster is created and fail like:

```
# sudo -u user pg_dump --version
Error: /etc/postgresql-common/user_clusters line 23: cluster 9.1/main does not exist
```

https://tickets.opscode.com/browse/COOK-3756
