### PR TITLE
[COOK-3611] Remove server bits and just install libpq-dev

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -28,7 +28,6 @@ rescue LoadError
   node.set['build_essential']['compiletime'] = true
   include_recipe "build-essential"
   include_recipe "postgresql::client"
-  include_recipe "postgresql::server"
 
   if node['postgresql']['enable_pgdg_yum']
     repo_rpm_url, repo_rpm_filename, repo_rpm_package = pgdgrepo_rpm_info
@@ -47,10 +46,10 @@ rescue LoadError
   node['postgresql']['client']['packages'].each do |pg_pack|
     resources("package[#{pg_pack}]").run_action(:install)
   end
-
-  node['postgresql']['server']['packages'].each do |pg_pack|
-    resources("package[#{pg_pack}]").run_action(:install)
-  end
+  
+  package "libpq-dev" do
+    action :nothing
+  end.run_action(:install)
 
   begin
     chef_gem "pg"


### PR DESCRIPTION
Server bits were included to fix the pg_gem error that many people got when they installed from omnibus, something like:

``` ruby

checking for pg_config... no
No pg_config... trying anyway. If building fails, please try again with
 --with-pg-config=/path/to/pg_config
checking for libpq-fe.h... no
Can't find the 'libpq-fe.h header
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of
necessary libraries and/or headers.  Check the mkmf.log file for more
details.  You may need configuration options.

Provided configuration options:
    --with-opt-dir
    --without-opt-dir
    --with-opt-include
    --without-opt-include=${opt-dir}/include
    --with-opt-lib
    --without-opt-lib=${opt-dir}/lib
    --with-make-prog
    --without-make-prog
    --srcdir=.
    --curdir
    --ruby=/home/demonchand/.rvm/rubies/ruby-1.9.2-p0/bin/ruby
    --with-pg
    --without-pg
    --with-pg-dir
    --without-pg-dir
    --with-pg-include
    --without-pg-include=${pg-dir}/include
    --with-pg-lib
    --without-pg-lib=${pg-dir}/lib
    --with-pg-config
    --without-pg-config
    --with-pg_config
    --without-pg_config

```

Instead of installing all the server packages, only installing libpq-dev fix the issue and is much lighter.
