### PR TITLE
[COOK-3851] Allow config file change notification type to be specified by attribute, defaulting to :restart

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver_plugin: vagrant
 driver_config:
-  require_chef_omnibus: true
+  require_chef_omnibus: 10.24.0
 
 platforms:
 - name: ubuntu-12.04

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The following attributes are set based on the platform, see the
   that should be installed on "client" systems.
 * `node['postgresql']['server']['packages']` - An array of package names
   that should be installed on "server" systems.
+* `node['postgresql']['server']['config_change_notify']` - Type of
+  notification triggered when a config file changes.
 * `node['postgresql']['contrib']['packages']` - An array of package names
   that could be installed on "server" systems for useful sysadmin tools.
 
@@ -399,6 +401,12 @@ platform and wish to use SSL in postgresql, then generate your SSL
 certificates and distribute them in your own cookbook, and set the
 `node['postgresql']['config']['ssl']` attribute to true in your
 role/cookboook/node.
+
+On server systems, the postgres server is restarted when a configuration
+file changes.  This can be changed to reload only by setting the
+following attribute:
+
+    node['postgresql']['server']['config_change_notify'] = :reload
 
 Chef Solo Note
 ==============

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 #
 
 default['postgresql']['enable_pgdg_apt'] = false
+default['postgresql']['server']['config_change_notify'] = :restart
 
 case node['platform']
 when "debian"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -57,12 +57,14 @@ when "debian"
   include_recipe "postgresql::server_debian"
 end
 
+change_notify = node['postgresql']['server']['config_change_notify']
+
 template "#{node['postgresql']['dir']}/postgresql.conf" do
   source "postgresql.conf.erb"
   owner "postgres"
   group "postgres"
   mode 0600
-  notifies :restart, 'service[postgresql]', :immediately
+  notifies change_notify, 'service[postgresql]', :immediately
 end
 
 template "#{node['postgresql']['dir']}/pg_hba.conf" do
@@ -70,7 +72,7 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   owner "postgres"
   group "postgres"
   mode 00600
-  notifies :restart, 'service[postgresql]', :immediately
+  notifies change_notify, 'service[postgresql]', :immediately
 end
 
 # NOTE: Consider two facts before modifying "assign-postgres-password":


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3851
