### PR TITLE
[COOK-4095] remove explicit ref to libpq-dev package

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -47,10 +47,6 @@ rescue LoadError
     resources("package[#{pg_pack}]").run_action(:install)
   end
   
-  package "libpq-dev" do
-    action :nothing
-  end.run_action(:install)
-
   begin
     chef_gem "pg"
   rescue Gem::Installer::ExtensionBuildError => e


### PR DESCRIPTION
This is to address https://tickets.opscode.com/browse/COOK-4095 - explicit reference of `libpq-dev` in `postgresql::ruby` is aborting the recipe execution.

There is no `libpq-dev` package on RedHat 6 (maybe other versions too). There is already code which installs client packages - this is supposed to be the way to deal with installing postgresql devel packages.
- [x] The explicit reference to libpq-dev has been removed
- [x] Tested and works fine on CentOS 6.3, chef 11.8.2 where pq devel is configured (in my case in Vagrant file) as:

```
        "client" => {
          "packages" => ["postgresql92", "postgresql92-devel"]
        }
```
