### PR TITLE
assign-postgres-password works on a custom postgresql port

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -86,7 +86,7 @@ end
 bash "assign-postgres-password" do
   user 'postgres'
   code <<-EOH
-echo "ALTER ROLE postgres ENCRYPTED PASSWORD '#{node['postgresql']['password']['postgres']}';" | psql
+echo "ALTER ROLE postgres ENCRYPTED PASSWORD '#{node['postgresql']['password']['postgres']}';" | psql -p #{node['postgresql']['config']['port']}
   EOH
   action :run
 end


### PR DESCRIPTION
Added psql -p #{node['postgresql']['config']['port']} to fix "assign-postgres-password" when a custom postgresql port is assigned
