### PR TITLE
[COOK-4283] - don't hardcode-install libpq-dev

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -47,10 +47,6 @@ rescue LoadError
     resources("package[#{pg_pack}]").run_action(:install)
   end
   
-  package "libpq-dev" do
-    action :nothing
-  end.run_action(:install)
-
   begin
     chef_gem "pg"
   rescue Gem::Installer::ExtensionBuildError => e


### PR DESCRIPTION
It's already installed in client_packages by the distros which need it
and it fails on SUSE, because that package does not exist. The
equivalent gets pulled as a dependency of postgresql-devel.
