### PR TITLE
Add default values for ssl_cert_file and ssl_key_file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -171,6 +171,8 @@ when 'debian'
   default['postgresql']['config']['datestyle'] = 'iso, mdy'
   default['postgresql']['config']['default_text_search_config'] = 'pg_catalog.english'
   default['postgresql']['config']['ssl'] = true
+  default['postgresql']['config']['ssl_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+  default['postgresql']['config']['ssl_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'
 when 'rhel', 'fedora', 'suse'
   default['postgresql']['config']['listen_addresses'] = 'localhost'
   default['postgresql']['config']['max_connections'] = 100


### PR DESCRIPTION
This is a fix for #106. Works on ubuntu 12.04 with postgres-9.3.
