### PR TITLE
Add ssl_key_file and ssl_cert_file attr to list of default Ubuntu attrib...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,6 +66,8 @@ when "ubuntu"
   default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]
   default['postgresql']['server']['packages'] = ["postgresql-#{node['postgresql']['version']}"]
   default['postgresql']['contrib']['packages'] = ["postgresql-contrib-#{node['postgresql']['version']}"]
+  default['postgresql']['config']['ssl_key_file'] = "/etc/ssl/private/ssl-cert-snakeoil.key"
+  default['postgresql']['config']['ssl_cert_file'] = "/etc/ssl/certs/ssl-cert-snakeoil.pem"
 
 when "fedora"
 


### PR DESCRIPTION
...utes

Running postgresql cookbook on Ubuntu 12.04 yields the following error when attempting to restart postgres during the initial chef run:

could not load server certificate file "server.crt": No such file or directory
   ...fail!
# Full error output:
# Error executing action `start` on resource 'service[postgresql]'
## Mixlib::ShellOut::ShellCommandFailed

Expected process to exit with [0], but received '1'
---- Begin output of /etc/init.d/postgresql start ----
STDOUT: \* Starting PostgreSQL 9.2 database server
- The PostgreSQL server failed to start. Please check the log output:
  2014-03-12 21:26:53 GMT FATAL:  could not load server certificate file "server.crt": No such file or directory
  ...fail!
  STDERR:
  ---- End output of /etc/init.d/postgresql start ----
  Ran /etc/init.d/postgresql start returned 1

---

Defining these attributes within the default_attributes hash was not populating the values within templates/default/postgresql.conf.erb as one would expect. 

default_attributes(
    'config' => {
      'ssl_key_file' => "/etc/ssl/private/ssl-cert-snakeoil.key",
      'ssl_cert_file' => "/etc/ssl/certs/ssl-cert-snakeoil.pem"
    }
  }
)

My commit adds two attributes to attributes/default.rb: ssl_key_file and ssl_cert_file which are the files for the default ssl package on Ubuntu: http://packages.ubuntu.com/saucy/ssl-cert
