### PR TITLE
Added trusty to pgdg repos

### DIFF
--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -1,4 +1,4 @@
-if not %w(etch lenny lucid precise sid squeeze wheezy).include? node['postgresql']['pgdg']['release_apt_codename']
+if not %w(etch lenny lucid precise sid squeeze wheezy trusty).include? node['postgresql']['pgdg']['release_apt_codename']
   raise "Not supported release by PGDG apt repository"
 end
 


### PR DESCRIPTION
The repo exists in http://apt.postgresql.org/pub/repos/apt/dists/trusty-pgdg/
