### PR TITLE
add support for ubuntu 14.04

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,8 +51,10 @@ when "ubuntu"
     default['postgresql']['version'] = "8.3"
   when node['platform_version'].to_f <= 11.04
     default['postgresql']['version'] = "8.4"
-  else
+  when node['platform_version'].to_f <= 13.10
     default['postgresql']['version'] = "9.1"
+  else
+    default['postgresql']['version'] = "9.3"
   end
 
   default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"
@@ -61,6 +63,12 @@ when "ubuntu"
     default['postgresql']['server']['service_name'] = "postgresql-#{node['postgresql']['version']}"
   else
     default['postgresql']['server']['service_name'] = "postgresql"
+  end
+
+  case
+  when node['platform_version'].to_f >= 14.04
+    default['postgresql']['config']['ssl_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+    default['postgresql']['config']['ssl_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'
   end
 
   default['postgresql']['client']['packages'] = ["postgresql-client-#{node['postgresql']['version']}","libpq-dev"]

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-if node['postgresql']['version'].to_f > 9.1 && platform_family?('ubuntu', 'debian')
+if node['postgresql']['version'].to_f > 9.3 && platform_family?('ubuntu', 'debian')
   node.default['postgresql']['enable_pgdg_apt'] = true
 end
 


### PR DESCRIPTION
Ubuntu 14.04 includes postgresql 9.3, and no longer symlinks the ssl
certificates into the postgresql data directory, so we need to set the
certificates to the snakeoil certs in /etc

I"ve tested this and it works in Ubuntu Server 14.04, and I checked that 13.10 is the cut off point for 9.1, so 14.04 must be the first version that uses 9.3.
