### PR TITLE
Update 'build-essential' attribute name.

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -25,7 +25,7 @@ begin
   require 'pg'
 rescue LoadError
 
-  node.set['build_essential']['compiletime'] = true
+  node.set['build-essential']['compile_time'] = true
   include_recipe "build-essential"
   include_recipe "postgresql::client"
 


### PR DESCRIPTION
'build_essential' and its attribute 'compiletime' have changed naming conventions.

"node['build_essential']['compiletime']"
to
"node['build-essential']['compile_time']"
