### PR TITLE
Update repository key location

### DIFF
--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -13,6 +13,6 @@ apt_repository 'apt.postgresql.org' do
   uri 'http://apt.postgresql.org/pub/repos/apt'
   distribution "#{node['postgresql']['pgdg']['release_apt_codename']}-pgdg"
   components ['main', node['postgresql']['version']]
-  key 'http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc'
+  key 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
   action :add
 end


### PR DESCRIPTION
Key location was changed today as per http://apt.postgresql.org/pub/repos/apt/README
