### PR TITLE
Fix PGDG apt key

### DIFF
--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -13,6 +13,6 @@ apt_repository 'apt.postgresql.org' do
   uri 'http://apt.postgresql.org/pub/repos/apt'
   distribution "#{node['postgresql']['pgdg']['release_apt_codename']}-pgdg"
   components ['main', node['postgresql']['version']]
-  key 'http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc'
+  key 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
   action :add
 end


### PR DESCRIPTION
Fixes 

```
  * remote_file[/var/chef/cache/ACCC4CF8.asc] action create
================================================================================
Error executing action `create` on resource 'remote_file[/var/chef/cache/ACCC4CF8.asc]'
================================================================================


Net::HTTPServerException
------------------------
404 "Not Found"


Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/apt/providers/repository.rb

 59:     remote_file cached_keyfile do
 60:       source new_resource.key
 61:       mode 00644
 62:       action :create
 63:     end
 64:   else



Compiled Resource:
------------------
# Declared in /var/chef/cache/cookbooks/apt/providers/repository.rb:59:in `install_key_from_uri'

remote_file("/var/chef/cache/ACCC4CF8.asc") do
  provider Chef::Provider::RemoteFile
  action [:create]
  retries 0
  retry_delay 2
  path "/var/chef/cache/ACCC4CF8.asc"
  backup 5
  atomic_update true
  source ["http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc"]
  use_etag true
  use_last_modified true
  cookbook_name "postgresql"
  mode 420
end
```
