### PR TITLE
Update URL for PGDG Key

### DIFF
--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -13,6 +13,6 @@ apt_repository 'apt.postgresql.org' do
   uri 'http://apt.postgresql.org/pub/repos/apt'
   distribution "#{node['postgresql']['pgdg']['release_apt_codename']}-pgdg"
   components ['main', node['postgresql']['version']]
-  key 'http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc'
+  key 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
   action :add
 end


### PR DESCRIPTION
The maintainers have changed where the key is meant to be located In October/November 2013, and can be seen in their documentation here:
http://wiki.postgresql.org/index.php?title=Apt&diff=21465&oldid=21447

Yesterday, the key was removed from the repo, causing these calls to fail. I spoke to one of the maintainers via IRC, and he's re-added it to the original location in the meantime, but will eventually be removed.
