### PR TITLE
Update default version for ubuntu 14.04 to 9.3

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,8 +51,10 @@ when "ubuntu"
     default['postgresql']['version'] = "8.3"
   when node['platform_version'].to_f <= 11.04
     default['postgresql']['version'] = "8.4"
-  else
+  when node['platform_version'].to_f <= 14.04
     default['postgresql']['version'] = "9.1"
+  else
+    default['postgresql']['version'] = "9.3"
   end
 
   default['postgresql']['dir'] = "/etc/postgresql/#{node['postgresql']['version']}/main"


### PR DESCRIPTION
The default postgres version for ubuntu 14.04 is now [9.3](https://launchpad.net/ubuntu/trusty/+source/postgresql-9.3). 
