### PR TITLE
add a recipe to install python client library packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ in other recipes. The build-essential packages and postgresql client
 packages will be installed during the compile phase, so that the
 native extensions of `pg` can be compiled.
 
+python
+------
+
+Install the python client library packages.
+
 server
 ------
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,7 @@ long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           "3.4.1"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
+recipe            "postgresql::python", "Install python library packages"
 recipe            "postgresql::client", "Installs postgresql client package(s)"
 recipe            "postgresql::server", "Installs postgresql server packages, templates"
 recipe            "postgresql::server_redhat", "Installs postgresql server packages, redhat family style"

--- a/recipes/python.rb
+++ b/recipes/python.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Cookbook Name:: postgresql
+# Recipe:: python
+#
+# Author:: Ionuț Arțăriși (<iartarisi@suse.cz>)
+# Copyright 2014 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package "python-psycopg2"


### PR DESCRIPTION
the package name should be the same across all distro versions (I checked
SUSE, Fedora and Debian, the others are derivatives).
