### PR TITLE
Feature/remove pg dev dependency

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -54,12 +54,6 @@ rescue LoadError
     resources("package[#{pg_pack}]").run_action(:install)
   end
 
-  if ["debian","ubuntu"].include? node['platform']
-    package "libpq-dev" do
-      action :nothing
-    end.run_action(:install)
-  end
-
   begin
     chef_gem "pg"
   rescue Gem::Installer::ExtensionBuildError => e


### PR DESCRIPTION
FIXES #114
## To recap

This package was originally added as a mis-fix because someone inadvertently
clobbered their client packages.

hw-cookbooks#88

Apart from being "the wrong way" to fix the problem, it also resulted in breaking centos/redhat. CentOS was fixed by wrapping in an "if debian?" here:

https://github.com/hw-cookbooks/postgresql/pull/96/files

But really it never should have been added, per @jeremyolliver

hw-cookbooks#96 (comment)

This block was to be removed in hw-cookbooks#99

But somehow this code is still [in develop](https://github.com/hw-cookbooks/postgresql/blob/develop/recipes/ruby.rb#L57).

It looks like #99 targeted a different base branch than #96, so perhaps there was a botched merge.

Phew!
