### PR TITLE
[pg gem] modify PATH instead of providing hard-coded path to pg_config executable

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -94,11 +94,7 @@ EOS
 
     lib_builder = execute 'generate pg gem Makefile' do
       # [COOK-3490] pg gem install requires full path on RHEL
-      if node['platform_family'] == 'rhel'
-        command "#{RbConfig.ruby} extconf.rb --with-pg-config=/usr/pgsql-#{node['postgresql']['version']}/bin/pg_config"
-      else
-        command "#{RbConfig.ruby} extconf.rb"
-      end
+      command "PATH=$PATH:/usr/pgsql-#{node['postgresql']['version']}/bin #{RbConfig.ruby} extconf.rb"
       cwd ext_dir
       action :nothing
     end


### PR DESCRIPTION
Not all RHEL variants will have pg_config in `/usr/pgsql-#{node['postgresql']['version']}/bin`, but I believe appending this directory to the PATH when shelling out should help us find pg_config regardless of platform.
