### PR TITLE
[COOK-4737] Add flag to control database user password behavior

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 
 default['postgresql']['enable_pgdg_apt'] = false
 default['postgresql']['server']['config_change_notify'] = :restart
+default['postgresql']['assign_postgres_password'] = true
 
 case node['platform']
 when "debian"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -89,4 +89,5 @@ bash "assign-postgres-password" do
 echo "ALTER ROLE postgres ENCRYPTED PASSWORD '#{node['postgresql']['password']['postgres']}';" | psql -p #{node['postgresql']['config']['port']}
   EOH
   action :run
+  only_if { node['postgresql']['assign_postgres_password'] }
 end


### PR DESCRIPTION
There should be a way to control whether or not this ALTER statement is run. I needed this to work around having a read-only standby node, where I used the community cookbook to install and configure, but I couldn't change data on the read only node.
