### PR TITLE
Changed the Gem::Installer::ExtensionBuildError to a Mixlib::ShellOut::S...

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -56,7 +56,7 @@ rescue LoadError
 
   begin
     chef_gem "pg"
-  rescue Mixlib::ShellOut::ShellCommandFailed => e
+  rescue Gem::Installer::ExtensionBuildError, Mixlib::ShellOut::ShellCommandFailed => e
     # Are we an omnibus install?
     raise if RbConfig.ruby.scan(%r{(chef|opscode)}).empty?
     # Still here, must be omnibus. Lets make this thing install!


### PR DESCRIPTION
...hellCommandFailed to temporarily band-aid the error that causes new Chef versions to miss the chef-solo workaround
