### PR TITLE
Coerce max_connections to an integer

### DIFF
--- a/recipes/config_pgtune.rb
+++ b/recipes/config_pgtune.rb
@@ -107,15 +107,15 @@ con =
 }.fetch(db_type)
 
 if (node['postgresql'].attribute?('config_pgtune') && node['postgresql']['config_pgtune'].attribute?('max_connections'))
-  max_connections = node['postgresql']['config_pgtune']['max_connections']
-  if (max_connections.match(/\A[1-9]\d*\Z/) == nil)
+  max_connections = node['postgresql']['config_pgtune']['max_connections'].to_i
+  if max_connections <= 0
     Chef::Application.fatal!([
         "Bad value (#{max_connections})",
         "for node['postgresql']['config_pgtune']['max_connections'] attribute.",
         "Valid values are non-zero integers only."
       ].join(' '))
   end
-  con = max_connections.to_i
+  con = max_connections
 end
 
 # Parse out total_memory option, or use value detected by Ohai.


### PR DESCRIPTION
max_connections must be a non-zero integer. It so happens that calling
to_i on things that aren't integers returns 0, which should fail
validation correctly.

Otherwise, if you specify the max_connections attribute as an integer,
the existing (convoluted) check fails because you can't use match() on a Fixnum.
