### PR TITLE
Don't include the pgdg recipes on the wrong machine types

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -19,20 +19,18 @@
 # limitations under the License.
 #
 
-if platform_family?('ubuntu', 'debian') && node['postgresql']['version'].to_f > 9.3
+if platform_family?('debian') && node['postgresql']['version'].to_f > 9.3
   node.default['postgresql']['enable_pgdg_apt'] = true
 end
 
-if(node['postgresql']['enable_pgdg_apt'])
+if(node['postgresql']['enable_pgdg_apt']) and platform_family?('debian')
   include_recipe 'postgresql::apt_pgdg_postgresql'
 end
 
-if(node['postgresql']['enable_pgdg_yum'])
+if(node['postgresql']['enable_pgdg_yum']) and platform_family?('rhel')
   include_recipe 'postgresql::yum_pgdg_postgresql'
 end
 
 node['postgresql']['client']['packages'].each do |pg_pack|
-
   package pg_pack
-
 end


### PR DESCRIPTION
Don't bother including enable_pgdg_apt on rhel, and don't include
enable_pgdg_yum on Debian.

If not, setting enable_pgdg_yum somewhere central like an environment
blows up on machines that don't use yum, likewise for apt.
