### PR TITLE
Fix SSL for PostgreSQL versions < 9.2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -178,6 +178,7 @@ when 'debian'
   default['postgresql']['config']['ssl_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem' if node['postgresql']['version'].to_f >= 9.2
   default['postgresql']['config']['ssl_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'if node['postgresql']['version'].to_f >= 9.2
 when 'rhel', 'fedora', 'suse'
+  default['postgresql']['config']['data_directory'] = node['postgresql']['dir']
   default['postgresql']['config']['listen_addresses'] = 'localhost'
   default['postgresql']['config']['port'] = 5432
   default['postgresql']['config']['max_connections'] = 100

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -71,6 +71,20 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   notifies change_notify, 'service[postgresql]', :immediately
 end
 
+# Versions prior to 9.2 do not have a config file option to set the SSL
+# key and cert path, and instead expect them to be in a specific location.
+if node['postgresql']['version'].to_f < 9.2 && node['postgresql']['config'].attribute?('ssl_cert_file')
+  link ::File.join(node['postgresql']['config']['data_directory'], 'server.crt') do
+    to node['postgresql']['config']['ssl_cert_file']
+  end
+end
+
+if node['postgresql']['version'].to_f < 9.2 && node['postgresql']['config'].attribute?('ssl_key_file')
+  link ::File.join(node['postgresql']['config']['data_directory'], 'server.key') do
+    to node['postgresql']['config']['ssl_key_file']
+  end
+end
+
 # NOTE: Consider two facts before modifying "assign-postgres-password":
 # (1) Passing the "ALTER ROLE ..." through the psql command only works
 #     if passwordless authorization was configured for local connections.

--- a/templates/default/postgresql.conf.erb
+++ b/templates/default/postgresql.conf.erb
@@ -5,6 +5,7 @@
 
 <% node['postgresql']['config'].sort.each do |key, value| %>
 <% next if value.nil? -%>
+<% next if node['postgresql']['version'].to_f < 9.2 && /ssl_.*._file/.match(key) -%>
 <%= key %> = <%=
   case value
   when String


### PR DESCRIPTION
## Abstract of Change

Prior to version 9.2 of PostgreSQL there was not a ssl_key_file or ssl_cert_file argument. This fixes support for these older version to ensure certificates are used properly.
## Validation

This is something we will need to discuss... I was able to validate: server-ubuntu-1404, server-ubuntu-1204, and server-centos-70. However, `kitchen test` failed for 10.04 for unrelated reasons, so I just converged some by doing kitchen converge on the ones I listed.

Given this information, I was not comfortable with including the following patch in the PR as I am not confident it will work on all Linux flavors, nevertheless it is required to validate the feature on Ubuntu/Debian. I did noticed there is a 'feature/test-kitchen-refresh' branch, I am curious to find out if some of the issues have been resolved here.
- [ ] Patch your .kitchen.yml with the following patch:

``` diff
diff --git a/.kitchen.yml b/.kitchen.yml
index 394fbf3..5750b03 100644
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -76,6 +76,9 @@ suites:
     postgresql:
       password:
         postgres: "iloverandompasswordsbutthiswilldo"
+      config:
+        ssl_key_file: "/etc/ssl/private/ssl-cert-snakeoil.key"
+        ssl_cert_file: "/etc/ssl/certs/ssl-cert-snakeoil.pem"

 - name: apt-pgdg-server
   run_list:
```
- [ ] Run kitchen converge ^server (this may fail on some platforms with unrelated failing tests)
- [ ] Instances with Postgresql < 9.2 should have a symlink to the server.crt and server.key files
- [ ] Instances with Postgresql >= 9.2 should havethe ssl_cert_file and ssl_key_file options in the postgresql.conf file.
## Questions
- How and where do I write tests for this patch? Minitest? ChefSpec? ServerSpec?
- Should we add a separate test kitchen suite for this specific flag, or is doing so overkill?
- Whats the better way to handle validation on RHEL variants given the different path and naming convention?
