### PR TITLE
give postgres a fighting chance to recover from incorrect configuration

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -44,15 +44,6 @@ else
   node.save
 end
 
-# Include the right "family" recipe for installing the server
-# since they do things slightly differently.
-case node['platform_family']
-when "rhel", "fedora", "suse"
-  include_recipe "postgresql::server_redhat"
-when "debian"
-  include_recipe "postgresql::server_debian"
-end
-
 change_notify = node['postgresql']['server']['config_change_notify']
 
 template "#{node['postgresql']['dir']}/postgresql.conf" do
@@ -69,6 +60,15 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   group "postgres"
   mode 00600
   notifies change_notify, 'service[postgresql]', :immediately
+end
+
+# Include the right "family" recipe for installing the server
+# since they do things slightly differently.
+case node['platform_family']
+when "rhel", "fedora", "suse"
+  include_recipe "postgresql::server_redhat"
+when "debian"
+  include_recipe "postgresql::server_debian"
 end
 
 # NOTE: Consider two facts before modifying "assign-postgres-password":


### PR DESCRIPTION
suppose you typo a setting in node['postgresql']['config'] or node['postgresql']['pg_hba']

the cookbook will converge the postgresql service before rendering the broken templates, then tries to restart postgres, which fails. After fixing the issue with your config attributes you wind up in a chicken and egg situation, where the cookbook attempts to start the (now) stopped postgresql service but cannot because the broken config files have not been replaced yet, as all the configuration templates live further down the resource collection than service['postgresql']. 

This patch simply moves the definition of the templates to just before the definition of the service.
