### PR TITLE
Reorder where service is defined in relation to config files

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -45,15 +45,6 @@ else
   node.save
 end
 
-# Include the right "family" recipe for installing the server
-# since they do things slightly differently.
-case node['platform_family']
-when "rhel", "fedora", "suse"
-  include_recipe "postgresql::server_redhat"
-when "debian"
-  include_recipe "postgresql::server_debian"
-end
-
 change_notify = node['postgresql']['server']['config_change_notify']
 
 template "#{node['postgresql']['dir']}/postgresql.conf" do
@@ -70,6 +61,15 @@ template "#{node['postgresql']['dir']}/pg_hba.conf" do
   group "postgres"
   mode 00600
   notifies change_notify, 'service[postgresql]', :immediately
+end
+
+# Include the right "family" recipe for installing the server
+# since they do things slightly differently.
+case node['platform_family']
+when "rhel", "fedora", "suse"
+  include_recipe "postgresql::server_redhat"
+when "debian"
+  include_recipe "postgresql::server_debian"
 end
 
 # Versions prior to 9.2 do not have a config file option to set the SSL


### PR DESCRIPTION
We found that bad configuration settings can prevent the server from starting up. Since the service was defined before the config files, it was impossible for Chef to update the config files before starting the server. Chef would abort on startup error and never update the config files.

This pull request and patch solves this problem by defining the configuration files before the service definition. Chef has the opportunity to correct the files before attempting to start the service again.

No specs or tests included, how do you write one that handles things that span multiple chef runs and cover long term maintainability of servers?
