### PR TITLE
Blank LIBPATHENV in RbConfig

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -75,6 +75,8 @@ LDFLAGS
   RbConfig::CONFIG[key].gsub!(/-Wl[^ ]+( ?\\/[^ ]+)?/, '')
   RbConfig::MAKEFILE_CONFIG[key].gsub!(/-Wl[^ ]+( ?\\/[^ ]+)?/, '')
 end
+RbConfig::CONFIG['LIBPATHENV'] = ''
+RbConfig::MAKEFILE_CONFIG['LIBPATHENV'] = ''
 RbConfig::CONFIG['RPATHFLAG'] = ''
 RbConfig::MAKEFILE_CONFIG['RPATHFLAG'] = ''
 EOS


### PR DESCRIPTION
This fixes the issue relating to #212 where `pg` fails on Chef 12.0.1

Tested with other versions of Chef and there is no compatibility issues that came up.
