### PR TITLE
Only save postgresql password to node attributes when it's actually set

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -41,8 +41,10 @@ else
   # login for user 'postgres'). However, a random password wouldn't be
   # useful if it weren't saved as clear text in Chef Server for later
   # retrieval.
-  node.set_unless['postgresql']['password']['postgres'] = secure_password
-  node.save
+  if node['postgresql']['assign_postgres_password']
+    node.set_unless['postgresql']['password']['postgres'] = secure_password
+    node.save
+  end
 end
 
 # Include the right "family" recipe for installing the server


### PR DESCRIPTION
This prevents random passwords taining node configuration attributes
