### PR TITLE
Don't use PGDG for 9.4 on Debian

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -19,7 +19,7 @@ include_recipe 'postgresql::ca_certificates'
 
 case node['platform_family']
 when 'debian'
-  if node['postgresql']['version'].to_f > 9.3
+  if node['postgresql']['version'].to_f > 9.4
     node.normal['postgresql']['enable_pgdg_apt'] = true
   end
 


### PR DESCRIPTION
I realise there was a small mistake in my earlier pull request (it broke Wheezy) so you used someone else's but they missed the line about which versions to enable PGDG for.
