### PR TITLE
Anticipate cluster creation on debian to fix fail when locales are not setup

### DIFF
--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -26,7 +26,7 @@ end
 execute 'Set locale and Create cluster' do
   command 'export LC_ALL=C; /usr/bin/pg_createcluster ' + node['postgresql']['version'] + ' main'
   action :run
-  not_if { ::File.directory?('/var/lib/postgresql/' + node['postgresql']['version'] + '/main') }
+  not_if { ::File.directory?(node['postgresql']['config']['data_directory']) }
 end
 
 include_recipe "postgresql::server_conf"

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -23,16 +23,16 @@ node['postgresql']['server']['packages'].each do |pg_pack|
 
 end
 
+execute 'Set locale and Create cluster' do
+  command 'export LC_ALL=C; /usr/bin/pg_createcluster ' + node['postgresql']['version'] + ' main'
+  action :run
+  not_if { ::File.directory?('/var/lib/postgresql/' + node['postgresql']['version'] + '/main') }
+end
+
 include_recipe "postgresql::server_conf"
 
 service "postgresql" do
   service_name node['postgresql']['server']['service_name']
   supports :restart => true, :status => true, :reload => true
   action [:enable, :start]
-end
-
-execute 'Set locale and Create cluster' do
-  command 'export LC_ALL=C; /usr/bin/pg_createcluster --start ' + node['postgresql']['version'] + ' main'
-  action :run
-  not_if { ::File.directory?('/etc/postgresql/' + node['postgresql']['version'] + '/main') }
 end


### PR DESCRIPTION
Will fix enclosing directory not found when creating postgresql.conf on
debian systems without a locale properly setup when postgresql packages
are installed.

Should fix #261 #249 #248 #147 
