### PR TITLE
add attribute to use templates from other cookbook in server_conf.rb recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -220,6 +220,11 @@ default['postgresql']['enable_pgdg_yum'] = false
 
 default['postgresql']['initdb_locale'] = nil
 
+# Allow overriding which cookbook templates in server_conf.rb recipe can
+# come from. When nil, use this cookbook.
+default['postgresql']['server_conf']['postgresql'] = nil
+default['postgresql']['server_conf']['pg_hba'] = nil
+
 # The PostgreSQL RPM Building Project built repository RPMs for easy
 # access to the PGDG yum repositories. Links to RPMs for installation
 # on the supported version/platform combinations are listed at
@@ -546,4 +551,3 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
     }
   },
 };
-

--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -17,7 +17,10 @@
 
 change_notify = node['postgresql']['server']['config_change_notify']
 
+cb_postgresql = node['postgresql']['server_conf'].fetch('postgresql', nil)
+
 template "#{node['postgresql']['dir']}/postgresql.conf" do
+  cookbook cb_postgresql if cb_postgresql
   source "postgresql.conf.erb"
   owner "postgres"
   group "postgres"
@@ -25,7 +28,10 @@ template "#{node['postgresql']['dir']}/postgresql.conf" do
   notifies change_notify, 'service[postgresql]', :immediately
 end
 
+cb_pg_hba = node['postgresql']['server_conf'].fetch('pg_hba', nil)
+
 template "#{node['postgresql']['dir']}/pg_hba.conf" do
+  cookbook cb_pg_hba if cb_pg_hba
   source "pg_hba.conf.erb"
   owner "postgres"
   group "postgres"


### PR DESCRIPTION
Added attributes which default to `nil`.

When not `nil`, allows using templates in recipes/server_conf.rb (e.g. for postgresql.conf, pg_hba.conf) from another cookbook.

This is simpler than requiring the use of chef-rewind and allows for overriding the templates when postgresql community cookbook is included in a LWRP (e.g. with `run_context.include_recipe`), where `rewind` may not behave as expected.

Intent to address https://github.com/hw-cookbooks/postgresql/issues/274
