### PR TITLE
Fix server name references. WIth PostgreSQL, the init.d service is na…

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -17,6 +17,14 @@
 
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 
+# Simply define the service but do not use it yet
+# This is to simply allow service restarts to properly have a service to reference
+service "postgresql" do
+  service_name node['postgresql']['server']['service_name']
+  supports :restart => true, :status => true, :reload => true
+  action :nothing
+end
+
 include_recipe "postgresql::client"
 
 # randomly generate postgres password, unless using solo - see README

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -26,8 +26,6 @@ end
 include_recipe "postgresql::server_conf"
 
 service "postgresql" do
-  service_name node['postgresql']['server']['service_name']
-  supports :restart => true, :status => true, :reload => true
   action [:enable, :start]
 end
 

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -94,7 +94,5 @@ end
 include_recipe "postgresql::server_conf"
 
 service "postgresql" do
-  service_name svc_name
-  supports :restart => true, :status => true, :reload => true
   action [:enable, :start]
 end


### PR DESCRIPTION
…med "postgresql-9.4" and thus any early restarts via `notifies :restart, 'service[postgresql]'`. Currently the logic has the Chef service resource definition occurring after the restarts, which leads to failures. This fix is to resolve the order.

Note: please double check in case I am misunderstanding how the logic is suppose to work.
