### PR TITLE
Fix systemd service file include when using pgdg packages

### DIFF
--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -84,7 +84,14 @@ end
 if node['postgresql']['server']['init_package'] == 'systemd'
 
   if node['platform_family'] == 'rhel'
-    template '/etc/systemd/system/postgresql.service' do
+
+    if node['postgresql']['use_pgdg_packages']
+      template_path = "/etc/systemd/system/postgresql-#{node['postgresql']['version']}.service"
+    else
+      template_path = '/etc/systemd/system/postgresql.service'
+    end
+
+    template template_path do
       source 'postgresql.service.erb'
       owner 'root'
       group 'root'

--- a/templates/default/postgresql.service.erb
+++ b/templates/default/postgresql.service.erb
@@ -1,5 +1,9 @@
+<% if node['postgresql']['use_pgdg_packages'] %>
+.include /usr/lib/systemd/system/postgresql-<%= node['postgresql']['version'] %>.service
+<% else %>[Service]
 .include /usr/lib/systemd/system/postgresql.service
-[Service]
++<% end %>
+
 Environment=
 Environment=PGPORT=<%= node['postgresql']['config']['port'] %>
 Environment=PGDATA=<%= node['postgresql']['config']['data_directory'] %>


### PR DESCRIPTION
When using pgdg it was not possible defining a custom data_dir. This PR fixes the issue by updating the systemd service filename & including the version.
This fixes #354 
