### PR TITLE
Custom resource for installing extensions

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -283,8 +283,7 @@ module Opscode
     #           Note an empty output could mean psql couldn't connect.
     # This is easiest for 1-field (1-row, 1-col) results, otherwise
     # it will be complex to parse the results.
-    def execute_sql(query)
-      db_name = node['postgresql']['database_name']
+    def execute_sql(query, db_name = node['postgresql']['database_name'])
       # query could be a String or an Array of String
       statement = query.is_a?(String) ? query : query.join("\n")
       @execute_sql ||= begin
@@ -303,18 +302,6 @@ module Opscode
           raise 'SQL ERROR'
         end
         cmd.stdout.chomp
-      end
-    end
-
-    #######
-    # Function to determine if a standard contrib extension is already installed.
-    #   Input: Extension name
-    #   Output: true or false
-    # Best use as a not_if gate on bash "install-#{pg_ext}-extension" resource.
-    def extension_installed?(pg_ext)
-      @extension_installed ||= begin
-        installed = execute_sql("select 'installed' from pg_extension where extname = '#{pg_ext}';")
-        installed =~ /^installed$/
       end
     end
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -277,21 +277,6 @@ module Opscode
     end
 
     #######
-    # Function to determine the name of the system's default timezone.
-    def get_result_orig(query)
-      # query could be a String or an Array of String
-      stdin = if query.is_a?(String)
-                query
-              else
-                query.join("\n")
-              end
-      @get_result ||= begin
-        cmd = shell_out('cat', input: stdin)
-        cmd.stdout
-      end
-    end
-
-    #######
     # Function to execute an SQL statement in the default database.
     #   Input: Query could be a single String or an Array of String.
     #   Output: A String with |-separated columns and \n-separated rows.

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -286,23 +286,21 @@ module Opscode
     def execute_sql(query, db_name = node['postgresql']['database_name'])
       # query could be a String or an Array of String
       statement = query.is_a?(String) ? query : query.join("\n")
-      @execute_sql ||= begin
-        cmd = shell_out("psql -q --tuples-only --no-align -d #{db_name} -f -",
-                        user: 'postgres',
-                        input: statement
-                       )
-        # If psql fails, generally the postgresql service is down.
-        # Instead of aborting chef with a fatal error, let's just
-        # pass these non-zero exitstatus back as empty cmd.stdout.
-        if cmd.exitstatus == 0 && !cmd.stderr.empty?
-          # An SQL failure is still a zero exitstatus, but then the
-          # stderr explains the error, so let's rais that as fatal.
-          Chef::Log.fatal("psql failed executing this SQL statement:\n#{statement}")
-          Chef::Log.fatal(cmd.stderr)
-          raise 'SQL ERROR'
-        end
-        cmd.stdout.chomp
+      cmd = shell_out("psql -q --tuples-only --no-align -d #{db_name} -f -",
+                      user: 'postgres',
+                      input: statement
+                     )
+      # If psql fails, generally the postgresql service is down.
+      # Instead of aborting chef with a fatal error, let's just
+      # pass these non-zero exitstatus back as empty cmd.stdout.
+      if cmd.exitstatus == 0 && !cmd.stderr.empty?
+        # An SQL failure is still a zero exitstatus, but then the
+        # stderr explains the error, so let's rais that as fatal.
+        Chef::Log.fatal("psql failed executing this SQL statement:\n#{statement}")
+        Chef::Log.fatal(cmd.stderr)
+        raise 'SQL ERROR'
       end
+      cmd.stdout.chomp
     end
 
     # End the Opscode::PostgresqlHelpers module

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -29,14 +29,6 @@ include_recipe 'postgresql::server'
 # node attribute node['postgresql']['database_name'].
 if node['postgresql']['contrib'].attribute?('extensions')
   node['postgresql']['contrib']['extensions'].each do |pg_ext|
-    bash "install-#{pg_ext}-extension" do
-      user 'postgres'
-      code <<-EOH
-        echo 'CREATE EXTENSION IF NOT EXISTS "#{pg_ext}";' | psql -d "#{db_name}"
-      EOH
-      action :run
-      ::Chef::Resource.send(:include, Opscode::PostgresqlHelpers)
-      not_if { extension_installed?(pg_ext) }
-    end
+    postgresql_extension "#{db_name}/#{pg_ext}"
   end
 end

--- a/resources/extension.rb
+++ b/resources/extension.rb
@@ -1,0 +1,58 @@
+#
+# Cookbook Name:: postgresql
+# Resource:: extension
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include Opscode::PostgresqlHelpers
+
+# name property should take the form:
+# database/extension
+
+property :database, String,
+         required: true,
+         default: lazy { name.scan(%r{\A[^/]+(?=/)}).first }
+
+property :extension, String,
+         required: true,
+         default: lazy { name.scan(%r{(?<=/)[^/]+\Z}).first }
+
+default_action :create
+
+action :create do
+  bash "CREATE EXTENSION #{name}" do
+    code psql("CREATE EXTENSION IF NOT EXISTS \"#{extension}\"")
+    user 'postgres'
+    action :run
+    not_if { installed? }
+  end
+end
+
+action :drop do
+  bash "DROP EXTENSION #{name}" do
+    code psql("DROP EXTENSION IF EXISTS \"#{extension}\"")
+    user 'postgres'
+    action :run
+    only_if { installed? }
+  end
+end
+
+def psql(query)
+  "psql -d #{database} <<< '\\set ON_ERROR_STOP on\n#{query};'"
+end
+
+def installed?
+  query = "SELECT 'installed' FROM pg_extension WHERE extname = '#{extension}';"
+  !(execute_sql(query, database) =~ /^installed$/).nil?
+end


### PR DESCRIPTION
The contrib recipe is very restrictive in that it only allows you to install a single set of extensions into a single database for any given node.

This new resource allows installation of any extension into any database at any time. It also supports dropping extensions.

The name property takes the form `database/extension` to ensure that resources remain unique when dealing with extensions across multiple databases.

The call to psql now enables `ON_ERROR_STOP` to ensure that the operation does not silently fail.

The contrib recipe has been kept but now utilises the resource. The resource does not install postgresql-contrib so the recipe should still be used for this.