### PR TITLE
Ensure `postgresql::ruby` can handle over-generalized `enable_pgdg_*` attributes

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -32,7 +32,7 @@ rescue LoadError
   node.override['build-essential']['compile_time'] = true
   include_recipe 'build-essential'
 
-  if node['postgresql']['enable_pgdg_yum']
+  if node['postgresql']['enable_pgdg_yum'] and platform_family? 'redhat'
     package 'ca-certificates' do
       action :nothing
     end.run_action(:upgrade)
@@ -56,7 +56,7 @@ rescue LoadError
 
   end
 
-  if node['postgresql']['enable_pgdg_apt']
+  if node['postgresql']['enable_pgdg_apt'] and platform_family? 'debian'
     include_recipe 'postgresql::apt_pgdg_postgresql'
     resources('apt_repository[apt.postgresql.org]').run_action(:add)
 


### PR DESCRIPTION
https://github.com/sous-chefs/postgresql-cookbook/blob/master/recipes/client.rb#L21-L33

The `postgresql::client` recipe has some helpful conditionals so that setting these don't cause the wrong platform's recipe to be included on the other type when attributes are set like so:

```
default['postgresql']['enable_pgdg_apt'] = true
default['postgresql']['enable_pgdg_yum'] = true
```
This is forgiving when you want to have a simple wrapper cookbook, and set these in that cookbook's attributes file.

Unfortunately, `postgresql::ruby` doesn't do the same checks:
https://github.com/sous-chefs/postgresql-cookbook/blob/master/recipes/ruby.rb#L35

We should add these. It will make coobook setup a bit simpler for devops end-users :)