### PR TITLE
Move some test suites into a test recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,7 +20,7 @@ platforms:
 suites:
 - name: default
   run_list:
-  - recipe[postgresql]
+  - recipe[test:default]
 
 - name: contrib
   run_list:
@@ -28,26 +28,13 @@ suites:
 
 - name: apt-pgdg-client
   run_list:
-  - recipe[apt]
-  - recipe[postgresql]
+  - recipe[test::apt-pgdg-client]
   excludes: [ "centos-6.8", "centos-7.2", "opensuse-13.2", "opensuse-leap-42.1", "fedora-24" ]
-  attributes:
-    postgresql:
-      enable_pgdg_apt: true
-      version: "9.4"
-      client:
-        packages: [ "postgresql-client-9.4", "libpq-dev" ]
 
 - name: yum-pgdg-client
   run_list:
-  - recipe[postgresql]
+  - recipe[test::yum-pgdg-client]
   excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-16.04", "debian-7.11", "debian-8.5", "opensuse-13.2", "opensuse-leap-42.1" ]
-  attributes:
-    postgresql:
-      enable_pgdg_yum: true
-      version: "9.4"
-      client:
-        packages: [ "postgresql94" ]
 
 - name: ruby
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,11 +24,7 @@ suites:
 
 - name: contrib
   run_list:
-  - recipe[postgresql::contrib]
-  attributes:
-    postgresql:
-      password:
-        postgres: "iloverandompasswordsbutthiswilldo"
+  - recipe[test::contrib]
 
 - name: apt-pgdg-client
   run_list:

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,5 @@ metadata
 
 group :integration do
   cookbook 'yum'
-  cookbook 'java'
+  cookbook 'test', path: './test/cookbooks/test'
 end

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -1,0 +1,7 @@
+name 'test'
+maintainer 'Sous Chefs'
+maintainer_email 'help@sous-chefs.org'
+license 'Apache 2.0'
+description 'Installs/Configures test'
+version '0.1.0'
+depends 'postgresql'

--- a/test/cookbooks/test/recipes/apt-pgdg-client.rb
+++ b/test/cookbooks/test/recipes/apt-pgdg-client.rb
@@ -1,0 +1,7 @@
+apt_update 'update' if platform_family?('debian')
+
+node.default['postgresql']['enable_pgdg_apt'] = true
+node.default['postgresql']['version'] = '9.4'
+node.default['postgresql']['client']['packages'] = ['postgresql-client-9.4', 'libpq-dev']
+
+include_recipe 'postgresql::default'

--- a/test/cookbooks/test/recipes/contrib.rb
+++ b/test/cookbooks/test/recipes/contrib.rb
@@ -1,0 +1,6 @@
+apt_update 'update' if platform_family?('debian')
+
+node.default['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'
+node.default['postgresql']['contrib']['extensions'] = %w( plpgsql xml2)
+
+include_recipe 'postgresql::contrib'

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,0 +1,3 @@
+apt_update 'update' if platform_family?('debian')
+
+include_recipe 'postgresql::default'

--- a/test/cookbooks/test/recipes/yum-pgdg-client.rb
+++ b/test/cookbooks/test/recipes/yum-pgdg-client.rb
@@ -1,0 +1,5 @@
+node.default['postgresql']['enable_pgdg_yum'] = true
+node.default['postgresql']['version'] = '9.4'
+node.default['postgresql']['client']['packages'] = ['postgresql94']
+
+include_recipe 'postgresql::default'


### PR DESCRIPTION
These are the first of many. It also expands the testing to actually setup extensions in the contrib recipe, which was missing

Signed-off-by: Tim Smith <tsmith@chef.io>