### PR TITLE
Require Chef 12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Installs and configures PostgreSQL as a client or a server.
 
 ### Chef
 
-- Chef 11+
+- Chef 12.1+
 
 ### Cookbooks
 
-- `apt`
+- `compat_resource`
 - `openssl`
 - `build-essential`
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,9 +5,9 @@ license           'Apache 2.0'
 description       'Installs and configures postgresql for clients or servers'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '5.2.0'
-source_url        'https://github.com/sous-chefs/postgresql' if respond_to?(:source_url)
-issues_url        'https://github.com/sous-chefs/postgresql/issues' if respond_to?(:issues_url)
-chef_version      '>= 11.0' if respond_to?(:chef_version)
+source_url        'https://github.com/sous-chefs/postgresql'
+issues_url        'https://github.com/sous-chefs/postgresql/issues'
+chef_version      '>= 12.1' if respond_to?(:chef_version)
 recipe            'postgresql::default', 'Includes postgresql::client'
 recipe            'postgresql::ruby', 'Installs pg gem for Ruby bindings'
 recipe            'postgresql::client', 'Installs postgresql client package(s)'
@@ -26,6 +26,6 @@ end
   supports el, '>= 6.0'
 end
 
-depends 'apt', '>= 1.9.0'
+depends 'compat_resource', '>= 12.16.3'
 depends 'build-essential', '>= 2.0.0'
 depends 'openssl', '>= 4.0'

--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -1,5 +1,3 @@
-include_recipe 'apt::default'
-
 apt_repository 'apt.postgresql.org' do
   uri 'http://apt.postgresql.org/pub/repos/apt'
   distribution "#{node['postgresql']['pgdg']['release_apt_codename']}-pgdg"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -32,6 +32,4 @@ when 'rhel'
   end
 end
 
-node['postgresql']['client']['packages'].each do |pkg|
-  package pkg
-end
+package node['postgresql']['client']['packages']

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -19,9 +19,7 @@ db_name = node['postgresql']['database_name']
 
 # Install the PostgreSQL contrib package(s) from the distribution,
 # as specified by the node attributes.
-node['postgresql']['contrib']['packages'].each do |pg_pack|
-  package pg_pack
-end
+package node['postgresql']['contrib']['packages']
 
 include_recipe 'postgresql::server'
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'postgresql::default' do
+describe 'Client installation' do
   platforms = {
     'ubuntu' => {
       'versions' => ['12.04', '14.04', '16.04'],
@@ -27,12 +27,12 @@ describe 'postgresql::default' do
             platform: platform.to_s,
             version: version.to_s
           ) do |node|
-            node.normal['postgresql']['password']['postgres'] = 'ilikewaffles'
-          end.converge(described_recipe)
+            node.default['postgresql']['password']['postgres'] = 'ilikewaffles'
+          end.converge('postgresql::client')
         end
 
-        it 'runs no tests' do
-          expect(chef_run)
+        it 'converges successfully' do
+          expect { :chef_run }.to_not raise_error
         end
       end
     end

--- a/spec/unit/debian_server_spec.rb
+++ b/spec/unit/debian_server_spec.rb
@@ -10,8 +10,8 @@ describe 'debian::postgresql::server' do
     ) do |node|
       node.automatic['memory']['total'] = '2048kB'
       node.automatic['ipaddress'] = '1.1.1.1'
-      node.normal['postgresql']['version'] = '9.1'
-      node.normal['postgresql']['password']['postgres'] = 'password'
+      node.default['postgresql']['version'] = '9.1'
+      node.default['postgresql']['password']['postgres'] = 'password'
     end
     runner.converge('postgresql::server')
   end
@@ -26,12 +26,8 @@ describe 'debian::postgresql::server' do
     expect(chef_run).to install_package('postgresql-9.1')
   end
 
-  it 'Install postgresql 9.1 client' do
-    expect(chef_run).to install_package('postgresql-client-9.1')
-  end
-
-  it 'Install postgresql 9.1 dev files' do
-    expect(chef_run).to install_package('libpq-dev')
+  it 'Install postgresql 9.1 client and dev packages' do
+    expect(chef_run).to install_package(['postgresql-client-9.1', 'libpq-dev'])
   end
 
   it 'Enable and start service postgresql' do

--- a/spec/unit/opensuse_131_server_spec.rb
+++ b/spec/unit/opensuse_131_server_spec.rb
@@ -29,12 +29,8 @@ describe 'opensuse::postgresql::server' do
     expect(chef_run).to install_package('postgresql92-server')
   end
 
-  it 'Install postgresql 9.2 client' do
-    expect(chef_run).to install_package('postgresql92')
-  end
-
-  it 'Install postgresql 9.2 dev files' do
-    expect(chef_run).to install_package('postgresql92-devel')
+  it 'Install postgresql 9.2 client and dev packages' do
+    expect(chef_run).to install_package(['postgresql92', 'postgresql92-devel'])
   end
 
   it 'Enable and start service postgresql' do

--- a/spec/unit/opensuse_132_server_spec.rb
+++ b/spec/unit/opensuse_132_server_spec.rb
@@ -29,12 +29,8 @@ describe 'opensuse::postgresql::server' do
     expect(chef_run).to install_package('postgresql93-server')
   end
 
-  it 'Install postgresql 9.3 client' do
-    expect(chef_run).to install_package('postgresql93')
-  end
-
-  it 'Install postgresql 9.3 dev files' do
-    expect(chef_run).to install_package('postgresql93-devel')
+  it 'Install postgresql 9.3 client and dev packages' do
+    expect(chef_run).to install_package(['postgresql93', 'postgresql93-devel'])
   end
 
   it 'Enable and start service postgresql' do


### PR DESCRIPTION
I merged in a custom resource so we’re already requiring it. This completes the process and adds multi package installs to speed up converge times.

Signed-off-by: Tim Smith <tsmith@chef.io>