### PR TITLE
Deprecate the ca-certificates recipe

### DIFF
--- a/recipes/ca_certificates.rb
+++ b/recipes/ca_certificates.rb
@@ -1,6 +1,1 @@
-# some older linux distributions have expired certificate bundles
-# for pgdg repositories. Upgrading this package before trying to
-# install postgresql is necessary.
-package 'ca-certificates' do
-  action :upgrade
-end
+Chef::Log.warn('The postgresql::ca-certificates recipe has been deprecated and will be removed in the next major release of the cookbook')

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-include_recipe 'postgresql::ca_certificates'
-
 case node['platform_family']
 when 'debian'
   if node['postgresql']['version'].to_f > 9.3

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-include_recipe 'postgresql::ca_certificates'
-
 ::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
 
 include_recipe 'postgresql::client'


### PR DESCRIPTION
No community cookbook should be upgrading packages. The user should be responsible for this and modern distros shouldn’t need this package updated anyways.

Signed-off-by: Tim Smith <tsmith@chef.io>