### PR TITLE
Fix RHEL platform_family detection in "ruby" recipe

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -32,7 +32,7 @@ rescue LoadError
   node.override['build-essential']['compile_time'] = true
   include_recipe 'build-essential'
 
-  if node['postgresql']['enable_pgdg_yum'] && platform_family?('redhat')
+  if node['postgresql']['enable_pgdg_yum'] && platform_family?('rhel')
     package 'ca-certificates' do
       action :nothing
     end.run_action(:upgrade)


### PR DESCRIPTION
The correct platform family name is `'rhel'`, not `'redhat'`. 


It causes the failure of  `postgres::ruby` in cookbook version v5.2.0 on RHEL systems with PGDG enabled. The section below this "#platform_family?" condition is skipped, so the package could not be installed:

```
       Recipe: postgresql::ruby
         * yum_package[postgresql93] action install
           * No candidate version available for postgresql93
           ================================================================================
           Error executing action `install` on resource 'yum_package[postgresql93]'
           ================================================================================

           Chef::Exceptions::Package
           -------------------------
           No candidate version available for postgresql93

         Cookbook Trace:
         ---------------
           /tmp/kitchen/cache/cookbooks/postgresql/recipes/ruby.rb:76:in `block in from_file'
           /tmp/kitchen/cache/cookbooks/postgresql/recipes/ruby.rb:73:in `each'
           /tmp/kitchen/cache/cookbooks/postgresql/recipes/ruby.rb:73:in `rescue in from_file'
           /tmp/kitchen/cache/cookbooks/postgresql/recipes/ruby.rb:21:in `from_file'
           /tmp/kitchen/cache/cookbooks/database/recipes/postgresql.rb:20:in `from_file'
           /tmp/kitchen/cache/cookbooks/confluence/recipes/database.rb:62:in `from_file'
           /tmp/kitchen/cache/cookbooks/confluence/recipes/default.rb:22:in `from_file'
           /tmp/kitchen/cache/cookbooks/confluence_test/recipes/postgresql.rb:21:in `from_file'
```

Reproduced in TravisCI build for "confluence" cookbook: https://travis-ci.org/parallels-cookbooks/confluence/jobs/188228201

This PR fixes that issue.