### PR TITLE
Revert "Support for PostgreSQL 9.6 #370. not tested on RedHat." becau…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -203,7 +203,6 @@ when 'debian'
   default['postgresql']['config']['datestyle'] = 'iso, mdy'
   default['postgresql']['config']['default_text_search_config'] = 'pg_catalog.english'
   default['postgresql']['config']['ssl'] = true
-  default['postgresql']['config']['dynamic_shared_memory_type'] = 'sysv' if node['postgresql']['version'].to_f >= 9.6
 when 'rhel', 'fedora', 'suse'
   default['postgresql']['config']['listen_addresses'] = 'localhost'
   default['postgresql']['config']['port'] = 5432
@@ -221,7 +220,6 @@ when 'rhel', 'fedora', 'suse'
   default['postgresql']['config']['lc_numeric'] = 'en_US.UTF-8'
   default['postgresql']['config']['lc_time'] = 'en_US.UTF-8'
   default['postgresql']['config']['default_text_search_config'] = 'pg_catalog.english'
-  default['postgresql']['config']['dynamic_shared_memory_type'] = 'sysv' if node['postgresql']['version'].to_f >= 9.6
 end
 
 default['postgresql']['pg_hba'] = [


### PR DESCRIPTION
### Description

Revert "Support for PostgreSQL 9.6 #370. not tested on RedHat." because 'dynamic_shared_memory_type' needed only on some platforms/versions. I mostly run Ubuntu 16.04 LTS with PostgreSQL 9.6.1 now and this setting isn't needed any more (it was needed on older versions). Also, according to PostgreSQL documention best value should be set by default. 
 
### Issues Resolved

Do not set value that PostgreSQL should set by default.
