### PR TITLE
Kitchen refactor

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,9 +1,3 @@
-<%
-rpm_based_platforms = %w(centos-5 centos-6 centos-7 fedora-25)
-deb_based_platforms = %w(ubuntu-12.04 ubuntu-14.04 ubuntu-16.04 debian-7 debian-8)
-opensuse_platforms = %w(opensuse-13.2 opensuse-leap)
-%>
----
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
@@ -15,261 +9,88 @@ transport:
 provisioner:
   name: dokken
 
-verifier:
-  name: inspec
-
 platforms:
-- name: debian-7
-  verifier:
-    attributes:
-      pg_version: '9.1'
-  driver:
-    image: debian:7
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+  - name: debian-7
+    driver:
+      image: debian:7
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
-- name: debian-8
-  driver:
-    image: debian:8
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+  - name: debian-8
+    driver:
+      image: debian:8
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
-- name: centos-5
-  verifier:
-    attributes:
-      pg_version: '8.4'
-  driver:
-    image: centos:5
-    platform: rhel
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN yum install -y which initscripts net-tools wget
+  - name: centos-5
+    driver:
+      image: centos:5
+      platform: rhel
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN yum install -y which initscripts net-tools wget
 
-- name: centos-6
-  verifier:
-    attributes:
-      pg_version: '8.4'
-  driver:
-    image: centos:6
-    platform: rhel
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN yum -y install which initscripts net-tools wget
+  - name: centos-6
+    driver:
+      image: centos:6
+      platform: rhel
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN yum -y install which initscripts net-tools wget
 
-- name: centos-7
-  verifier:
-    attributes:
-      pg_version: '9.2'
-  driver:
-    image: centos:7
-    platform: rhel
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN yum -y install lsof which systemd-sysv initscripts wget net-tools
+  - name: centos-7
+    driver:
+      image: centos:7
+      platform: rhel
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN yum -y install lsof which systemd-sysv initscripts wget net-tools
 
-- name: fedora-25
-  verifier:
-    attributes:
-      pg_version: '9.5'
-  driver:
-    image: fedora:25
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN dnf -y install yum which systemd-sysv initscripts wget net-tools
+  - name: fedora-25
+    driver:
+      image: fedora:25
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN dnf -y install yum which systemd-sysv initscripts wget net-tools
 
-- name: ubuntu-12.04
-  verifier:
-    attributes:
-      pg_version: '9.1'
-  driver:
-    image: ubuntu-upstart:12.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+  - name: ubuntu-12.04
+    driver:
+      image: ubuntu-upstart:12.04
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
-- name: ubuntu-14.04
-  verifier:
-    attributes:
-      pg_version: '9.3'
-  driver:
-    image: ubuntu-upstart:14.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+  - name: ubuntu-14.04
+    driver:
+      image: ubuntu-upstart:14.04
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
-- name: ubuntu-16.04
-  verifier:
-    attributes:
-      pg_version: '9.5'
-  driver:
-    image: ubuntu:16.04
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+  - name: ubuntu-16.04
+    driver:
+      image: ubuntu:16.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
-- name: opensuse-13.2
-  verifier:
-    attributes:
-      pg_version: '9.3'
-  driver:
-    image: opensuse:13.2
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
+  - name: opensuse-13.2
+    driver:
+      image: opensuse:13.2
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
 
-- name: opensuse-leap
-  driver:
-    image: opensuse:leap
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which hostname
-
-suites:
-- name: client
-  run_list:
-  - recipe[test::default]
-
-- name: contrib
-  run_list:
-  - recipe[test::contrib]
-
-- name: apt-pgdg-client
-  run_list:
-  - recipe[test::apt-pgdg-client]
-  excludes: <%= rpm_based_platforms + opensuse_platforms %>
-
-- name: yum-pgdg-client
-  run_list:
-  - recipe[test::yum-pgdg-client]
-  excludes: <%= deb_based_platforms + opensuse_platforms %>
-
-- name: ruby
-  run_list:
-  - recipe[postgresql::ruby]
-  - recipe[test::ruby]
-
-- name: server
-  run_list:
-  - recipe[postgresql::ruby]
-  - recipe[postgresql::server]
-  attributes:
-    postgresql:
-      password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
-
-- name: apt-pgdg-server
-  run_list:
-  - recipe[postgresql::ruby]
-  - recipe[postgresql::server]
-  excludes: <%= rpm_based_platforms + opensuse_platforms %>
-  attributes:
-    postgresql:
-      enable_pgdg_apt: true
-      version: '9.4'
-      dir: '/etc/postgresql/9.4/main'
-      server:
-        service_name: 'postgresql'
-        packages: [ 'postgresql-9.4' ]
-      client:
-        packages: [ 'postgresql-client-9.4', 'libpq-dev' ]
-      password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
-      config:
-        ssl_cert_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
-        ssl_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
-
-- name: yum-pgdg-server
-  run_list:
-  - recipe[postgresql::ruby]
-  - recipe[postgresql::server]
-  excludes: <%= deb_based_platforms + opensuse_platforms %>
-  attributes:
-    postgresql:
-      enable_pgdg_yum: true
-      version: '9.4'
-      server:
-        packages: [ 'postgresql94-server' ]
-        service_name: 'postgresql-9.4'
-      client:
-        packages: [ 'postgresql94', 'postgresql94-devel' ]
-      setup_script: 'postgresql94-setup'
-      password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
-
-- name: apt-pgdg-client-ruby
-  run_list:
-  - recipe[postgresql]
-  - recipe[postgresql::ruby]
-  - recipe[test::ruby]
-  excludes: <%= rpm_based_platforms + opensuse_platforms %>
-  attributes:
-    postgresql:
-      enable_pgdg_apt: true
-      version: '9.4'
-      client:
-        packages: [ 'postgresql-client-9.4', 'libpq-dev' ]
-
-- name: yum-pgdg-client-ruby
-  run_list:
-  - recipe[postgresql]
-  - recipe[postgresql::ruby]
-  - recipe[test::ruby]
-  excludes: <%= deb_based_platforms + opensuse_platforms %>
-  attributes:
-    postgresql:
-      enable_pgdg_yum: true
-      version: '9.4'
-      client:
-        packages: [ 'postgresql94', 'postgresql94-devel' ]
-
-- name: apt-pgdg-server-pg_stat_statements
-  run_list:
-  - recipe[postgresql::ruby]
-  - recipe[postgresql::contrib]
-  excludes: <%= rpm_based_platforms + opensuse_platforms %>
-  attributes:
-    postgresql:
-      enable_pgdg_apt: true
-      version: '9.4'
-      dir: '/etc/postgresql/9.4/main'
-      server:
-        service_name: 'postgresql'
-        packages: [ 'postgresql-9.4' ]
-      client:
-        packages: [ 'postgresql-client-9.4', 'libpq-dev' ]
-      password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
-      config:
-        shared_preload_libraries: 'pg_stat_statements'
-        ssl_cert_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
-        ssl_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
-      contrib:
-        extensions:
-          - pg_stat_statements
-
-- name: yum-pgdg-server-pg_stat_statements
-  run_list:
-  - recipe[postgresql::ruby]
-  - recipe[postgresql::contrib]
-  excludes: <%= deb_based_platforms + opensuse_platforms %>
-  attributes:
-    postgresql:
-      enable_pgdg_yum: true
-      version: '9.4'
-      server:
-        packages: [ 'postgresql94-server' ]
-        service_name: 'postgresql-9.4'
-      password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
-      config:
-        shared_preload_libraries: 'pg_stat_statements'
-      contrib:
-        extensions:
-          - pg_stat_statements
+  - name: opensuse-leap
+    driver:
+      image: opensuse:leap
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which hostname

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -26,14 +26,6 @@ platforms:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
-  - name: centos-5
-    driver:
-      image: centos:5
-      platform: rhel
-      pid_one_command: /sbin/init
-      intermediate_instructions:
-        - RUN yum install -y which initscripts net-tools wget
-
   - name: centos-6
     driver:
       image: centos:6
@@ -56,14 +48,6 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install yum which systemd-sysv initscripts wget net-tools
-
-  - name: ubuntu-12.04
-    driver:
-      image: ubuntu-upstart:12.04
-      pid_one_command: /sbin/init
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
   - name: ubuntu-14.04
     driver:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,10 +24,6 @@ platforms:
     driver:
       box: bento/debian-8.5
 
-  - name: centos-5
-    driver:
-      box: bento/centos-5.11
-
   - name: centos-6
     driver:
       box: bento/centos-6.8
@@ -39,7 +35,6 @@ platforms:
   - name: fedora-25
     driver:
       box: bento/fedora-25
-    run_list: yum::dnf_yum_compat
 
   - name: ubuntu-12.04
     driver:
@@ -92,7 +87,7 @@ suites:
   attributes:
     postgresql:
       password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
+        postgres: iloverandompasswordsbutthiswilldo
 
 - name: apt-pgdg-server
   run_list:
@@ -103,17 +98,17 @@ suites:
     postgresql:
       enable_pgdg_apt: true
       version: '9.4'
-      dir: '/etc/postgresql/9.4/main'
+      dir: /etc/postgresql/9.4/main
       server:
-        service_name: 'postgresql'
+        service_name: postgresql
         packages: [ 'postgresql-9.4' ]
       client:
         packages: [ 'postgresql-client-9.4', 'libpq-dev' ]
       password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
+        postgres: iloverandompasswordsbutthiswilldo
       config:
-        ssl_cert_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
-        ssl_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
+        ssl_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
+        ssl_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
 
 - name: yum-pgdg-server
   run_list:
@@ -126,12 +121,12 @@ suites:
       version: '9.4'
       server:
         packages: [ 'postgresql94-server' ]
-        service_name: 'postgresql-9.4'
+        service_name: postgresql-9.4
       client:
         packages: [ 'postgresql94', 'postgresql94-devel' ]
-      setup_script: 'postgresql94-setup'
+      setup_script: postgresql94-setup
       password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
+        postgres: iloverandompasswordsbutthiswilldo
 
 - name: apt-pgdg-client-ruby
   run_list:
@@ -168,18 +163,18 @@ suites:
     postgresql:
       enable_pgdg_apt: true
       version: '9.4'
-      dir: '/etc/postgresql/9.4/main'
+      dir: /etc/postgresql/9.4/main
       server:
-        service_name: 'postgresql'
+        service_name: postgresql
         packages: [ 'postgresql-9.4' ]
       client:
         packages: [ 'postgresql-client-9.4', 'libpq-dev' ]
       password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
+        postgres: iloverandompasswordsbutthiswilldo
       config:
-        shared_preload_libraries: 'pg_stat_statements'
-        ssl_cert_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
-        ssl_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
+        shared_preload_libraries: pg_stat_statements
+        ssl_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
+        ssl_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
       contrib:
         extensions:
           - pg_stat_statements
@@ -195,11 +190,11 @@ suites:
       version: '9.4'
       server:
         packages: [ 'postgresql94-server' ]
-        service_name: 'postgresql-9.4'
+        service_name: postgresql-9.4
       password:
-        postgres: 'iloverandompasswordsbutthiswilldo'
+        postgres: iloverandompasswordsbutthiswilldo
       config:
-        shared_preload_libraries: 'pg_stat_statements'
+        shared_preload_libraries: pg_stat_statements
       contrib:
         extensions:
           - pg_stat_statements

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,21 +1,65 @@
+<%
+rpm_based_platforms = %w(centos-5 centos-6 centos-7 fedora-25)
+deb_based_platforms = %w(ubuntu-12.04 ubuntu-14.04 ubuntu-16.04 debian-7 debian-8)
+opensuse_platforms = %w(opensuse-13.2 opensuse-leap)
+%>
+---
 driver:
   name: vagrant
+  customize:
+    cableconnected1: 'on'
 
 provisioner:
   name: chef_zero
 
+verifier:
+  name: inspec
+
 platforms:
-  - name: centos-6.8
-  - name: centos-7.2
-  - name: debian-7.11
-  - name: debian-8.6
+  - name: debian-7
+    driver:
+      box: bento/debian-7.11
+
+  - name: debian-8
+    driver:
+      box: bento/debian-8.5
+
+  - name: centos-5
+    driver:
+      box: bento/centos-5.11
+
+  - name: centos-6
+    driver:
+      box: bento/centos-6.8
+
+  - name: centos-7
+    driver:
+      box: bento/centos-7.2
+
   - name: fedora-25
+    driver:
+      box: bento/fedora-25
     run_list: yum::dnf_yum_compat
-  - name: opensuse-13.2
-  - name: opensuse-leap-42.1
+
   - name: ubuntu-12.04
+    driver:
+      box: bento/ubuntu-12.04
+
   - name: ubuntu-14.04
+    driver:
+      box: bento/ubuntu-14.04
+
   - name: ubuntu-16.04
+    driver:
+      box: bento/ubuntu-16.04
+
+  - name: opensuse-13.2
+    driver:
+      box: bento/opensuse-13.2
+
+  - name: opensuse-leap
+    driver:
+      box: bento/opensuse-leap-42.1
 
 suites:
 - name: client
@@ -29,16 +73,17 @@ suites:
 - name: apt-pgdg-client
   run_list:
   - recipe[test::apt-pgdg-client]
-  excludes: [ "centos-6.8", "centos-7.2", "opensuse-13.2", "opensuse-leap-42.1", "fedora-25" ]
+  excludes: <%= rpm_based_platforms + opensuse_platforms %>
 
 - name: yum-pgdg-client
   run_list:
   - recipe[test::yum-pgdg-client]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-16.04", "debian-7.11", "debian-8.5", "opensuse-13.2", "opensuse-leap-42.1" ]
+  excludes: <%= deb_based_platforms + opensuse_platforms %>
 
 - name: ruby
   run_list:
   - recipe[postgresql::ruby]
+  - recipe[test::ruby]
 
 - name: server
   run_list:
@@ -47,92 +92,94 @@ suites:
   attributes:
     postgresql:
       password:
-        postgres: "iloverandompasswordsbutthiswilldo"
+        postgres: 'iloverandompasswordsbutthiswilldo'
 
 - name: apt-pgdg-server
   run_list:
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: [ "centos-6.8", "centos-7.2", "opensuse-13.2", "opensuse-leap-42.1", "fedora-23", "fedora-25" ]
+  excludes: <%= rpm_based_platforms + opensuse_platforms %>
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.4"
+      version: '9.4'
       dir: '/etc/postgresql/9.4/main'
       server:
-        service_name: "postgresql"
-        packages: [ "postgresql-9.4" ]
+        service_name: 'postgresql'
+        packages: [ 'postgresql-9.4' ]
       client:
-        packages: [ "postgresql-client-9.4", "libpq-dev" ]
+        packages: [ 'postgresql-client-9.4', 'libpq-dev' ]
       password:
-        postgres: "iloverandompasswordsbutthiswilldo"
+        postgres: 'iloverandompasswordsbutthiswilldo'
       config:
-        ssl_cert_file: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
-        ssl_key_file: "/etc/ssl/private/ssl-cert-snakeoil.key"
+        ssl_cert_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+        ssl_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
 
 - name: yum-pgdg-server
   run_list:
   - recipe[postgresql::ruby]
   - recipe[postgresql::server]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-16.04", "debian-8.5", "opensuse-13.2", "opensuse-leap-42.1" ]
+  excludes: <%= deb_based_platforms + opensuse_platforms %>
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.4"
+      version: '9.4'
       server:
-        packages: [ "postgresql94-server" ]
-        service_name: "postgresql-9.4"
+        packages: [ 'postgresql94-server' ]
+        service_name: 'postgresql-9.4'
       client:
-        packages: [ "postgresql94", "postgresql94-devel" ]
-      setup_script: "postgresql94-setup"
+        packages: [ 'postgresql94', 'postgresql94-devel' ]
+      setup_script: 'postgresql94-setup'
       password:
-        postgres: "iloverandompasswordsbutthiswilldo"
+        postgres: 'iloverandompasswordsbutthiswilldo'
 
 - name: apt-pgdg-client-ruby
   run_list:
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: [ "centos-6.8", "centos-7.2", "opensuse-13.2", "opensuse-leap-42.1", "fedora-23", "fedora-25" ]
+  - recipe[test::ruby]
+  excludes: <%= rpm_based_platforms + opensuse_platforms %>
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.4"
+      version: '9.4'
       client:
-        packages: [ "postgresql-client-9.4", "libpq-dev" ]
+        packages: [ 'postgresql-client-9.4', 'libpq-dev' ]
 
 - name: yum-pgdg-client-ruby
   run_list:
   - recipe[postgresql]
   - recipe[postgresql::ruby]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-16.04", "debian-7.11", "debian-8.5", "opensuse-13.2", "opensuse-leap-42.1" ]
+  - recipe[test::ruby]
+  excludes: <%= deb_based_platforms + opensuse_platforms %>
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.4"
+      version: '9.4'
       client:
-        packages: [ "postgresql94", "postgresql94-devel" ]
+        packages: [ 'postgresql94', 'postgresql94-devel' ]
 
 - name: apt-pgdg-server-pg_stat_statements
   run_list:
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: [ "centos-6.8", "centos-7.2", "opensuse-13.1", "opensuse-13.2", "fedora-23", "fedora-25" ]
+  excludes: <%= rpm_based_platforms + opensuse_platforms %>
   attributes:
     postgresql:
       enable_pgdg_apt: true
-      version: "9.4"
+      version: '9.4'
       dir: '/etc/postgresql/9.4/main'
       server:
-        service_name: "postgresql"
-        packages: [ "postgresql-9.4" ]
+        service_name: 'postgresql'
+        packages: [ 'postgresql-9.4' ]
       client:
-        packages: [ "postgresql-client-9.4", "libpq-dev" ]
+        packages: [ 'postgresql-client-9.4', 'libpq-dev' ]
       password:
-        postgres: "iloverandompasswordsbutthiswilldo"
+        postgres: 'iloverandompasswordsbutthiswilldo'
       config:
-        shared_preload_libraries: "pg_stat_statements"
-        ssl_cert_file: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
-        ssl_key_file: "/etc/ssl/private/ssl-cert-snakeoil.key"
+        shared_preload_libraries: 'pg_stat_statements'
+        ssl_cert_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+        ssl_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
       contrib:
         extensions:
           - pg_stat_statements
@@ -141,18 +188,18 @@ suites:
   run_list:
   - recipe[postgresql::ruby]
   - recipe[postgresql::contrib]
-  excludes: [ "ubuntu-12.04", "ubuntu-14.04", "ubuntu-16.04", "debian-8.5", "opensuse-13.2", "opensuse-leap-42-1" ]
+  excludes: <%= deb_based_platforms + opensuse_platforms %>
   attributes:
     postgresql:
       enable_pgdg_yum: true
-      version: "9.4"
+      version: '9.4'
       server:
-        packages: [ "postgresql94-server" ]
-        service_name: "postgresql-9.4"
+        packages: [ 'postgresql94-server' ]
+        service_name: 'postgresql-9.4'
       password:
-        postgres: "iloverandompasswordsbutthiswilldo"
+        postgres: 'iloverandompasswordsbutthiswilldo'
       config:
-        shared_preload_libraries: "pg_stat_statements"
+        shared_preload_libraries: 'pg_stat_statements'
       contrib:
         extensions:
           - pg_stat_statements

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,7 +22,7 @@ platforms:
 
   - name: debian-8
     driver:
-      box: bento/debian-8.5
+      box: bento/debian-8.6
 
   - name: centos-6
     driver:
@@ -30,7 +30,7 @@ platforms:
 
   - name: centos-7
     driver:
-      box: bento/centos-7.2
+      box: bento/centos-7.3
 
   - name: fedora-25
     driver:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,6 @@
 <%
-rpm_based_platforms = %w(centos-5 centos-6 centos-7 fedora-25)
-deb_based_platforms = %w(ubuntu-12.04 ubuntu-14.04 ubuntu-16.04 debian-7 debian-8)
+rpm_based_platforms = %w(centos-6 centos-7 fedora-25)
+deb_based_platforms = %w(ubuntu-14.04 ubuntu-16.04 debian-7 debian-8)
 opensuse_platforms = %w(opensuse-13.2 opensuse-leap)
 %>
 ---
@@ -35,10 +35,6 @@ platforms:
   - name: fedora-25
     driver:
       box: bento/fedora-25
-
-  - name: ubuntu-12.04
-    driver:
-      box: bento/ubuntu-12.04
 
   - name: ubuntu-14.04
     driver:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - KITCHEN_YAML=.kitchen.yml
   - KITCHEN_LOCAL_YAML=.kitchen.docker.yml
   matrix:
-  - INSTANCE=client-centos-5
+    #- INSTANCE=client-centos-5
   - INSTANCE=client-centos-6
   - INSTANCE=client-centos-7
   - INSTANCE=client-debian-7
@@ -35,7 +35,7 @@ env:
   - INSTANCE=client-ubuntu-1204
   - INSTANCE=client-ubuntu-1404
   - INSTANCE=client-ubuntu-1604
-  - INSTANCE=yum-pgdg-client-centos-5
+    #- INSTANCE=yum-pgdg-client-centos-5
   - INSTANCE=yum-pgdg-client-centos-6
   - INSTANCE=yum-pgdg-client-centos-7
   - INSTANCE=yum-pgdg-client-fedora-25
@@ -44,7 +44,7 @@ env:
   - INSTANCE=apt-pgdg-client-ubuntu-1204
   - INSTANCE=apt-pgdg-client-ubuntu-1404
   - INSTANCE=apt-pgdg-client-ubuntu-1604
-  - INSTANCE=yum-pgdg-client-ruby-centos-5
+    #- INSTANCE=yum-pgdg-client-ruby-centos-5
   - INSTANCE=yum-pgdg-client-ruby-centos-6
   - INSTANCE=yum-pgdg-client-ruby-centos-7
   - INSTANCE=yum-pgdg-client-ruby-fedora-25

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,16 @@ install: echo "skip bundle install"
 branches:
   only:
     - master
+    - kitchen_refactor
 
 services: docker
 
 env:
+  global:
+  - KITCHEN_YAML=.kitchen.yml
+  - KITCHEN_LOCAL_YAML=.kitchen.docker.yml
   matrix:
+  - INSTANCE=client-centos-5
   - INSTANCE=client-centos-6
   - INSTANCE=client-centos-7
   - INSTANCE=client-debian-7
@@ -30,6 +35,24 @@ env:
   - INSTANCE=client-ubuntu-1204
   - INSTANCE=client-ubuntu-1404
   - INSTANCE=client-ubuntu-1604
+  - INSTANCE=yum-pgdg-client-centos-5
+  - INSTANCE=yum-pgdg-client-centos-6
+  - INSTANCE=yum-pgdg-client-centos-7
+  - INSTANCE=yum-pgdg-client-fedora-25
+  - INSTANCE=apt-pgdg-client-debian-7
+  - INSTANCE=apt-pgdg-client-debian-8
+  - INSTANCE=apt-pgdg-client-ubuntu-1204
+  - INSTANCE=apt-pgdg-client-ubuntu-1404
+  - INSTANCE=apt-pgdg-client-ubuntu-1604
+  - INSTANCE=yum-pgdg-client-ruby-centos-5
+  - INSTANCE=yum-pgdg-client-ruby-centos-6
+  - INSTANCE=yum-pgdg-client-ruby-centos-7
+  - INSTANCE=yum-pgdg-client-ruby-fedora-25
+  - INSTANCE=apt-pgdg-client-ruby-debian-7
+  - INSTANCE=apt-pgdg-client-ruby-debian-8
+  - INSTANCE=apt-pgdg-client-ruby-ubuntu-1204
+  - INSTANCE=apt-pgdg-client-ruby-ubuntu-1404
+  - INSTANCE=apt-pgdg-client-ruby-ubuntu-1604
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
@@ -38,7 +61,7 @@ before_script:
   - /opt/chefdk/embedded/bin/cookstyle --version
   - /opt/chefdk/embedded/bin/foodcritic --version
 
-script: KITCHEN_LOCAL_YAML=.kitchen.docker.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
+script: /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
   - KITCHEN_YAML=.kitchen.yml
   - KITCHEN_LOCAL_YAML=.kitchen.docker.yml
   matrix:
-    #- INSTANCE=client-centos-5
   - INSTANCE=client-centos-6
   - INSTANCE=client-centos-7
   - INSTANCE=client-debian-7
@@ -35,7 +34,6 @@ env:
   - INSTANCE=client-ubuntu-1204
   - INSTANCE=client-ubuntu-1404
   - INSTANCE=client-ubuntu-1604
-    #- INSTANCE=yum-pgdg-client-centos-5
   - INSTANCE=yum-pgdg-client-centos-6
   - INSTANCE=yum-pgdg-client-centos-7
   - INSTANCE=yum-pgdg-client-fedora-25
@@ -44,7 +42,6 @@ env:
   - INSTANCE=apt-pgdg-client-ubuntu-1204
   - INSTANCE=apt-pgdg-client-ubuntu-1404
   - INSTANCE=apt-pgdg-client-ubuntu-1604
-    #- INSTANCE=yum-pgdg-client-ruby-centos-5
   - INSTANCE=yum-pgdg-client-ruby-centos-6
   - INSTANCE=yum-pgdg-client-ruby-centos-7
   - INSTANCE=yum-pgdg-client-ruby-fedora-25

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
   - INSTANCE=client-fedora-25
   - INSTANCE=client-opensuse-132
   - INSTANCE=client-opensuse-leap
-  - INSTANCE=client-ubuntu-1204
   - INSTANCE=client-ubuntu-1404
   - INSTANCE=client-ubuntu-1604
   - INSTANCE=yum-pgdg-client-centos-6
@@ -39,7 +38,6 @@ env:
   - INSTANCE=yum-pgdg-client-fedora-25
   - INSTANCE=apt-pgdg-client-debian-7
   - INSTANCE=apt-pgdg-client-debian-8
-  - INSTANCE=apt-pgdg-client-ubuntu-1204
   - INSTANCE=apt-pgdg-client-ubuntu-1404
   - INSTANCE=apt-pgdg-client-ubuntu-1604
   - INSTANCE=yum-pgdg-client-ruby-centos-6
@@ -47,7 +45,6 @@ env:
   - INSTANCE=yum-pgdg-client-ruby-fedora-25
   - INSTANCE=apt-pgdg-client-ruby-debian-7
   - INSTANCE=apt-pgdg-client-ruby-debian-8
-  - INSTANCE=apt-pgdg-client-ruby-ubuntu-1204
   - INSTANCE=apt-pgdg-client-ruby-ubuntu-1404
   - INSTANCE=apt-pgdg-client-ruby-ubuntu-1604
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://supermarket.chef.io'
 
 metadata

--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,5 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
-  cookbook 'yum'
   cookbook 'test', path: './test/cookbooks/test'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
 
 # Style tests. cookstyle (rubocop) and Foodcritic
 namespace :style do

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Attributes:: postgresql

--- a/attributes/yum_pgdg_packages.rb
+++ b/attributes/yum_pgdg_packages.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # The PostgreSQL RPM Building Project built repository RPMs for easy
 # access to the PGDG yum repositories. Links to RPMs for installation
 # on the supported version/platform combinations are listed at

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Library:: default
@@ -108,9 +109,8 @@ module Opscode
         return 'ymd'
         elseif (posD < posM)
         return 'dmy'
-      else
-        return 'mdy'
       end
+      'mdy'
     end
 
     #######

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 #
 # Cookbook:: postgresql
 # Library:: default
@@ -246,7 +246,7 @@ module Opscode
 
         resultbuf = [
           'Etc/GMT',
-          (-std_ofs > 0) ? '+' : '',
+          -std_ofs > 0 ? '+' : '',
           (-std_ofs).to_s,
         ].join('')
       end
@@ -288,8 +288,7 @@ module Opscode
       statement = query.is_a?(String) ? query : query.join("\n")
       cmd = shell_out("psql -q --tuples-only --no-align -d #{db_name} -f -",
                       user: 'postgres',
-                      input: statement
-                     )
+                      input: statement)
       # If psql fails, generally the postgresql service is down.
       # Instead of aborting chef with a fatal error, let's just
       # pass these non-zero exitstatus back as empty cmd.stdout.

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 name              'postgresql'
 maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'

--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 apt_repository 'apt.postgresql.org' do
   uri 'http://apt.postgresql.org/pub/repos/apt'
   distribution "#{node['postgresql']['pgdg']['release_apt_codename']}-pgdg"

--- a/recipes/ca_certificates.rb
+++ b/recipes/ca_certificates.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 Chef::Log.warn('The postgresql::ca-certificates recipe has been deprecated and will be removed in the next major release of the cookbook')

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: client

--- a/recipes/config_initdb.rb
+++ b/recipes/config_initdb.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: config_initdb

--- a/recipes/config_pgtune.rb
+++ b/recipes/config_pgtune.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: config_pgtune

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: contrib

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: default

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 #
 # Cookbook:: postgresql
 # Recipe:: ruby

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -31,7 +31,7 @@ rescue LoadError
   node.override['build-essential']['compile_time'] = true
   include_recipe 'build-essential'
 
-  if node['postgresql']['enable_pgdg_yum'] && platform_family?('rhel')
+  if node['postgresql']['enable_pgdg_yum'] && %w(rhel fedora).include?(node['platform_family'])
     include_recipe 'postgresql::yum_pgdg_postgresql'
 
     rpm_platform = node['platform']

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: ruby

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -31,7 +31,7 @@ rescue LoadError
   node.override['build-essential']['compile_time'] = true
   include_recipe 'build-essential'
 
-  if node['postgresql']['enable_pgdg_yum'] && %w(rhel fedora).include?(node['platform_family'])
+  if node['postgresql']['enable_pgdg_yum'] && platform_family?('rhel', 'fedora')
     include_recipe 'postgresql::yum_pgdg_postgresql'
 
     rpm_platform = node['platform']

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: server

--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: server

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: server

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe:: server

--- a/recipes/yum_pgdg_postgresql.rb
+++ b/recipes/yum_pgdg_postgresql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Recipe::yum_pgdg_postgresql
@@ -33,7 +34,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/#{pgdg_package}" do
 end
 
 # Install the PGDG repository RPM from the local file
-package (pgdg_package).to_s do
+package pgdg_package.to_s do
   provider Chef::Provider::Package::Rpm
   source "#{Chef::Config[:file_cache_path]}/#{pgdg_package}"
   action :install

--- a/recipes/yum_pgdg_postgresql.rb
+++ b/recipes/yum_pgdg_postgresql.rb
@@ -21,16 +21,20 @@
 rpm_platform = node['platform']
 rpm_platform_version = node['platform_version'].to_f.to_i.to_s
 arch = node['kernel']['machine']
+pg_version = node['postgresql']['version']
+pgdg_setup = node['postgresql']['pgdg']['repo_rpm_url'][pg_version][rpm_platform][rpm_platform_version][arch]
+pgdg_package = pgdg_setup['package']
+pgdg_repository = pgdg_setup['url']
 
 # Download the PGDG repository RPM as a local file
-remote_file "#{Chef::Config[:file_cache_path]}/#{node['postgresql']['pgdg']['repo_rpm_url'][node['postgresql']['version']][rpm_platform][rpm_platform_version][arch]['package']}" do
-  source "#{node['postgresql']['pgdg']['repo_rpm_url'][node['postgresql']['version']][rpm_platform][rpm_platform_version][arch]['url']}#{node['postgresql']['pgdg']['repo_rpm_url'][node['postgresql']['version']][rpm_platform][rpm_platform_version][arch]['package']}"
+remote_file "#{Chef::Config[:file_cache_path]}/#{pgdg_package}" do
+  source "#{pgdg_repository}#{pgdg_package}"
   mode '0644'
 end
 
 # Install the PGDG repository RPM from the local file
-package (node['postgresql']['pgdg']['repo_rpm_url'][node['postgresql']['version']][rpm_platform][rpm_platform_version][arch]['package']).to_s do
+package (pgdg_package).to_s do
   provider Chef::Provider::Package::Rpm
-  source "#{Chef::Config[:file_cache_path]}/#{node['postgresql']['pgdg']['repo_rpm_url'][node['postgresql']['version']][rpm_platform][rpm_platform_version][arch]['package']}"
+  source "#{Chef::Config[:file_cache_path]}/#{pgdg_package}"
   action :install
 end

--- a/resources/extension.rb
+++ b/resources/extension.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Cookbook:: postgresql
 # Resource:: extension

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'chefspec'
 require 'chefspec/berkshelf'
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'Client installation' do

--- a/spec/unit/debian_server_spec.rb
+++ b/spec/unit/debian_server_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'debian::postgresql::server' do

--- a/spec/unit/opensuse_131_server_spec.rb
+++ b/spec/unit/opensuse_131_server_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'opensuse::postgresql::server' do

--- a/spec/unit/opensuse_132_server_spec.rb
+++ b/spec/unit/opensuse_132_server_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'opensuse::postgresql::server' do

--- a/spec/unit/server_spec.rb
+++ b/spec/unit/server_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'postgresql::server' do

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 name 'test'
 maintainer 'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'

--- a/test/cookbooks/test/recipes/apt-pgdg-client.rb
+++ b/test/cookbooks/test/recipes/apt-pgdg-client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 apt_update 'update' if platform_family?('debian')
 
 node.default['postgresql']['enable_pgdg_apt'] = true

--- a/test/cookbooks/test/recipes/contrib.rb
+++ b/test/cookbooks/test/recipes/contrib.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 apt_update 'update' if platform_family?('debian')
 
 node.default['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 apt_update 'update' if platform_family?('debian')
 
 include_recipe 'postgresql::default'

--- a/test/cookbooks/test/recipes/ruby.rb
+++ b/test/cookbooks/test/recipes/ruby.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 file '/tmp/pg_gem_test.rb' do
   content "#!/opt/chef/embedded/bin/ruby\nrequire 'pg'"
   mode 0755

--- a/test/cookbooks/test/recipes/yum-pgdg-client.rb
+++ b/test/cookbooks/test/recipes/yum-pgdg-client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 node.default['postgresql']['enable_pgdg_yum'] = true
 node.default['postgresql']['version'] = '9.4'
 node.default['postgresql']['client']['packages'] = 'postgresql94'

--- a/test/integration/client/controls/client_spec.rb
+++ b/test/integration/client/controls/client_spec.rb
@@ -1,5 +1,53 @@
 # frozen_string_literal: true
-pg_version = attribute('pg_version', default: '9.4', description: 'PostgreSQL installed version by default')
+pg_version = attribute('pg_version', default: nil, description: 'PostgreSQL installed version by default')
+
+if pg_version.nil?
+  # Default values per platform/version
+  case os[:family]
+  when 'redhat'
+    case os[:release]
+    when /(5|6)\.\d+/
+      pg_version = '8.4'
+
+    when /7\.\d+/
+      pg_version = '9.2'
+    end
+
+  when 'fedora'
+    case os[:release]
+    when '25'
+      pg_version = '9.5'
+    end
+
+  when 'debian'
+    case os[:release]
+    when /7\.\d+/
+      pg_version = '9.1'
+
+    when /8\.\d+/
+      pg_version = '9.4'
+
+    # Ubuntu versions
+    when '12.04'
+      pg_version = '9.1'
+
+    when '14.04'
+      pg_version = '9.3'
+
+    when '16.04'
+      pg_version = '9.5'
+    end
+
+  when 'suse'
+    case os[:release]
+    when '42.2'
+      pg_version = '9.4'
+
+    when '13.2'
+      pg_version = '9.3'
+    end
+  end
+end
 
 describe command('/usr/bin/psql --help') do
   its('exit_status') { should eq 0 }


### PR DESCRIPTION
### Description

Removes the duplicity between .kitchen.yml and .kitchen.docker.yml.

There are only docker configs in .kitchen.docker.yml all the test suites definition, attributes, etc are in .kitchen.yml

I've included all the client suites/platforms in the travis file, do we really need to support centos-5?
### Contribution Check List

- [X] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable