### PR TITLE
I want to explicitly set the value of unix_socket_directory

### DIFF
--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -27,7 +27,7 @@ if node['platform_family'] == 'debian'
 
   if node['postgresql']['version'].to_f < 9.3
     node.normal['postgresql']['config']['unix_socket_directory'] = '/var/run/postgresql'
-  else
+  elsif !node['postgresql']['config'].key?('unix_socket_directories')
     node.normal['postgresql']['config']['unix_socket_directories'] = '/var/run/postgresql'
   end
 


### PR DESCRIPTION
### Description

Hi! Thank you for the best recipe.
I am using pacemaker now, I get the following error and want to invalidate `unix_socket_directories`.

```
# crm_mon -1
Last updated: Mon Feb 27 02:36:19 2017          Last change: Mon Feb 27 02:35:33 2017 by hacluster via crmd on db-master
Stack: corosync
Current DC: db-master (version 1.1.14-70404b0) - partition with quorum
2 nodes and 4 resources configured

Online: [ db-master db-slave ]


Failed Actions:
* pgsql_start_0 on db-master 'not configured' (6): call=25, status=complete, exitreason='In PostgreSQL 9.3 or higher, socketdir can't be empty if you define unix_socket_directories in the postgresql.conf.',
```
I would be happy if you could merge if possible.

### Issues Resolved

- none

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable