### PR TITLE
switch to realdirpath to resolve relative symlinks

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -201,7 +201,7 @@ module Opscode
         # in spite of what the sysadmin had specified in the symlink.
         # (There are many duplicates under tzdir, with the same timezone
         # content appearing as an average of 2-3 different file names.)
-        path = ::File.readlink('/etc/localtime')
+        path = ::File.realdirpath('/etc/localtime')
         bestzonename = path.gsub("#{tzdir}/", '')
       else # /etc/localtime is a file, so scan for it under tzdir
         localtime_content = File.read('/etc/localtime')


### PR DESCRIPTION
### Description

This fixes an issue with detecting system timezone when using relative symlinks for `/etc/localtime`

On centos 7.2 `/etc/localtime` gets symlinked to `../usr/share/zoneinfo/UTC`

This would cause the following gsub to set `bestzonename` to `..UTC`
instead of just `UTC`

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing. (Nothing new)
- [x] New functionality has been documented in the README if applicable (Nothing new)