### PR TITLE
Dont password default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the postgresql cookbook.
 
+## v6.1.2 (2017-xx-xx)
+
+- Disable postgres user password setting by default as the result is stored on the node object
+
+
 ## v6.1.1 (2017-03-08)
 
 - Fix pg gem installation on non-omnibus chef runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of the postgresql cookbook.
 
-## v6.1.2 (2017-xx-xx)
+## Unreleased
 
 - Disable postgres user password setting by default as the result is stored on the node object
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Install the `pg` gem under Chef's Ruby environment so it can be used in other re
 
 Includes the `server_debian` or `server_redhat` recipe to get the appropriate server packages installed and service managed. Also manages the configuration for the server:
 
-- generates a strong default password (via `openssl`) for `postgres`
+- generates a strong default password (via `openssl`) for `postgres` (off by default)
 - sets the password for postgres
 - manages the `postgresql.conf` file.
 - manages the `pg_hba.conf` file.
@@ -231,7 +231,7 @@ You may set `node['postgresql']['pgdg']['repo_rpm_url']` attributes to pick up r
 
 On systems that need to connect to a PostgreSQL database, add to a run list `recipe[postgresql]` or `recipe[postgresql::client]`.
 
-On systems that should be PostgreSQL servers, use `recipe[postgresql::server]` on a run list. This recipe does set a password for the `postgres` user. If you're using `chef server`, if the attribute `node['postgresql']['password']['postgres']` is not found, the recipe generates a random password and performs a node.save. (TODO: This is broken, as it disables the password.) If you're using `chef-solo`, you'll need to set the attribute `node['postgresql']['password']['postgres']` in your node's `json_attribs` file or in a role.
+On systems that should be PostgreSQL servers, use `recipe[postgresql::server]` on a run list. This recipe can set a password for the `postgres` user by doesn't by default as it's stored on the node object and this may be undesirable. If you're using `chef server`, if the attribute `node['postgresql']['password']['postgres']` is not found, the recipe generates a random password and performs a node.save. (TODO: This is broken, as it disables the password.) If you're using `chef-solo`, you'll need to set the attribute `node['postgresql']['password']['postgres']` in your node's `json_attribs` file or in a role.
 
 On Debian family systems, SSL will be enabled, as the packages on Debian/Ubuntu also generate the SSL certificates. If you use another platform and wish to use SSL in postgresql, then generate your SSL certificates and distribute them in your own cookbook, and set the `node['postgresql']['config']['ssl']` attribute to true in your role/cookboook/node.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['postgresql']['enable_pgdg_yum'] = false
 default['postgresql']['use_pgdg_packages'] = false
 
 default['postgresql']['server']['config_change_notify'] = :restart
-default['postgresql']['assign_postgres_password'] = true
+default['postgresql']['assign_postgres_password'] = false
 
 # Establish default database name
 default['postgresql']['database_name'] = 'template1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache 2.0'
 description       'Installs and configures postgresql for clients or servers'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '6.1.1'
+version           '6.1.2'
 source_url        'https://github.com/sous-chefs/postgresql'
 issues_url        'https://github.com/sous-chefs/postgresql/issues'
 chef_version      '>= 12.1' if respond_to?(:chef_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache 2.0'
 description       'Installs and configures postgresql for clients or servers'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '6.1.2'
+version           '6.1.1'
 source_url        'https://github.com/sous-chefs/postgresql'
 issues_url        'https://github.com/sous-chefs/postgresql/issues'
 chef_version      '>= 12.1' if respond_to?(:chef_version)


### PR DESCRIPTION
### Description

Set the assign postgres password attribute to `false` by default.

### Issues Resolved

Possibly #95 depending how you look at it.

### Contribution Check List

- [y] All tests pass.
- [n] New functionality includes testing.
- [y] New functionality has been documented in the README if applicable