### PR TITLE
Allow pgdg repository URL to be overridden with attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -239,6 +239,9 @@ default['postgresql']['pg_gem']['version'] = nil
 case node['platform_family']
 when 'debian'
   default['postgresql']['pgdg']['release_apt_codename'] = node['lsb']['codename']
+  default['postgresql']['pgdg']['repo_apt_url'] = 'http://apt.postgresql.org/pub/repos/apt'
+  default['postgresql']['pgdg']['repo_apt_key'] = 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+
 end
 
 default['postgresql']['initdb_locale'] = 'UTF-8'

--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 apt_repository 'apt.postgresql.org' do
-  uri 'http://apt.postgresql.org/pub/repos/apt'
+  uri node['postgresql']['pgdg']['repo_apt_url']
   distribution "#{node['postgresql']['pgdg']['release_apt_codename']}-pgdg"
   components ['main', node['postgresql']['version']]
-  key 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+  key node['postgresql']['pgdg']['repo_apt_key']
   action :add
 end


### PR DESCRIPTION
### Description

Currently the URL for the pgdg repository is hard coded. We have servers that are not allowed to access the public internet but can access our internal apt repository mirrors. We'd like to be able to override the URL and key for the pgdg repo to point at our internal mirrors. 

### Issues Resolved

None
### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable