### PR TITLE
Add of a new `['postgresql']['pg_gem']['source']` attribute to install `pg` gem in offline mode

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -232,8 +232,12 @@ default['postgresql']['pg_hba'] = [
 
 default['postgresql']['password'] = {}
 
-# set to install a specific version of the ruby gem pg
-# if attribute is not defined, install will pick the latest available pg gem
+# N.B. if the following attributes are not defined, install will pick the latest available
+# pg gem from the internet
+# - set this to install the ruby gem pg from a specific local file path
+# (useful when you can't get it from the internet)
+default['postgresql']['pg_gem']['source'] = nil
+# - set this to install a specific version of the ruby gem pg
 default['postgresql']['pg_gem']['version'] = nil
 
 case node['platform_family']


### PR DESCRIPTION
### Description

Add of a new `['postgresql']['pg_gem']['source']` attribute which enables using a local gem file for `pg` gem installation (done by `postgresql::ruby` recipe).

This way, it is now possible to install this gem without accessing the internet. For instance, the gem may be downloaded from a company server into Chef's cache path, and then the path to the downloaded file can be given to `postgresql::ruby` recipe using this new attribute:

``` ruby
remote_file "#{Chef::Config[:file_cache_path]}/pg-XXX.gem" do
  source "http://package-server.mydomain.com/gems/pg-XXX.gem"
  action :nothing
end.run_action(:create)

node.default['postgresql']['pg_gem']['source'] = "#{Chef::Config[:file_cache_path]}/pg-XXX.gem"

include_recipe 'postgresql::ruby'
```

### Issues Resolved

None.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable