### PR TITLE
Add AMI 2017 support for pgdg

### DIFF
--- a/attributes/yum_pgdg_packages.rb
+++ b/attributes/yum_pgdg_packages.rb
@@ -8,6 +8,16 @@
 default['postgresql']['pgdg']['repo_rpm_url'] = {
   '9.6' => {
     'amazon' => {
+      '2017' => {
+        'i386' => {
+          'url' => 'http://yum.postgresql.org/9.6/redhat/rhel-6-i386/',
+          'package' => 'pgdg-ami201503-96-9.6-3.noarch.rpm',
+        },
+        'x86_64' => {
+          'url' => 'http://yum.postgresql.org/9.6/redhat/rhel-6-x86_64/',
+          'package' => 'pgdg-ami201503-96-9.6-3.noarch.rpm',
+        },
+      },
       '2015' => {
         'i386' => {
           'url' => 'http://yum.postgresql.org/9.6/redhat/rhel-6-i386/',
@@ -120,6 +130,16 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
   },
   '9.5' => {
     'amazon' => {
+      '2017' => {
+        'i386' => {
+          'url' => 'http://yum.postgresql.org/9.5/redhat/rhel-6-i386/',
+          'package' => 'pgdg-ami201503-95-9.5-3.noarch.rpm',
+        },
+        'x86_64' => {
+          'url' => 'http://yum.postgresql.org/9.5/redhat/rhel-6-x86_64/',
+          'package' => 'pgdg-ami201503-95-9.5-3.noarch.rpm',
+        },
+      },
       '2015' => {
         'i386' => {
           'url' => 'http://yum.postgresql.org/9.5/redhat/rhel-6-i386/',
@@ -304,6 +324,16 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       },
     },
     'amazon' => {
+      '2017' => {
+        'i386' => {
+          'url' => 'http://yum.postgresql.org/9.4/redhat/rhel-6-i386/',
+          'package' => 'pgdg-ami201503-94-9.4-3.noarch.rpm',
+        },
+        'x86_64' => {
+          'url' => 'http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/',
+          'package' => 'pgdg-ami201503-94-9.4-3.noarch.rpm',
+        },
+      },
       '2015' => {
         'i386' => {
           'url' => 'http://yum.postgresql.org/9.4/redhat/rhel-6-i386/',
@@ -354,6 +384,16 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
   },
   '9.3' => {
     'amazon' => {
+      '2017' => {
+        'i386' => {
+          'url' => 'http://yum.postgresql.org/9.3/redhat/rhel-6-i386/',
+          'package' => 'pgdg-redhat93-9.3-3.noarch.rpm',
+        },
+        'x86_64' => {
+          'url' => 'http://yum.postgresql.org/9.3/redhat/rhel-6-x86_64/',
+          'package' => 'pgdg-redhat93-9.3-3.noarch.rpm',
+        },
+      },
       '2015' => {
         'i386' => {
           'url' => 'http://yum.postgresql.org/9.3/redhat/rhel-6-i386/',


### PR DESCRIPTION
### Description

Add AMI 2017 support for pgdg

Currently the only pgdg packages for postgresql 9.4, 9.5, and 9.6  are
the the ami 2015 packages, but after testing those with ami 2017
everything seems to work the same as ami 2015.

### Issues Resolved

None

### Contribution Check List

- [X] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable