### PR TITLE
Fix pgpd package name for postgresql 9.6 for AMI 2015 and 2017

### DIFF
--- a/attributes/yum_pgdg_packages.rb
+++ b/attributes/yum_pgdg_packages.rb
@@ -11,21 +11,21 @@ default['postgresql']['pgdg']['repo_rpm_url'] = {
       '2017' => {
         'i386' => {
           'url' => 'http://yum.postgresql.org/9.6/redhat/rhel-6-i386/',
-          'package' => 'pgdg-ami201503-96-9.6-3.noarch.rpm',
+          'package' => 'pgdg-ami201503-96-9.6-2.noarch.rpm',
         },
         'x86_64' => {
           'url' => 'http://yum.postgresql.org/9.6/redhat/rhel-6-x86_64/',
-          'package' => 'pgdg-ami201503-96-9.6-3.noarch.rpm',
+          'package' => 'pgdg-ami201503-96-9.6-2.noarch.rpm',
         },
       },
       '2015' => {
         'i386' => {
           'url' => 'http://yum.postgresql.org/9.6/redhat/rhel-6-i386/',
-          'package' => 'pgdg-ami201503-96-9.6-3.noarch.rpm',
+          'package' => 'pgdg-ami201503-96-9.6-2.noarch.rpm',
         },
         'x86_64' => {
           'url' => 'http://yum.postgresql.org/9.6/redhat/rhel-6-x86_64/',
-          'package' => 'pgdg-ami201503-96-9.6-3.noarch.rpm',
+          'package' => 'pgdg-ami201503-96-9.6-2.noarch.rpm',
         },
       },
     },


### PR DESCRIPTION

### Description

Fix pgpd package name for postgresql 9.6 for AMI 2015 and 2017. It looks like there was a typo in the package name

### Issues Resolved

None

### Contribution Check List

- [X] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable