### PR TITLE
Set Postgresql version to 9.6 for Debian 9.0 Stretch (resolve #445)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,6 +33,10 @@ platforms:
     driver:
       box: bento/debian-8.6
 
+  - name: debian-9
+    driver:
+      box: bento/debian-9.1
+
   - name: fedora-25
     driver:
       box: bento/fedora-25

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,12 +65,18 @@ when 'debian'
     default['postgresql']['client']['packages'] = ['postgresql-client-9.1', 'libpq-dev']
     default['postgresql']['server']['packages'] = ['postgresql-9.1']
     default['postgresql']['contrib']['packages'] = ['postgresql-contrib-9.1']
-  else # 8+
+  elsif node['platform_version'].to_i == 8
     default['postgresql']['version'] = '9.4'
     default['postgresql']['dir'] = '/etc/postgresql/9.4/main'
     default['postgresql']['client']['packages'] = ['postgresql-client-9.4', 'libpq-dev']
     default['postgresql']['server']['packages'] = ['postgresql-9.4']
     default['postgresql']['contrib']['packages'] = ['postgresql-contrib-9.4']
+  else # 9+
+    default['postgresql']['version'] = '9.6'
+    default['postgresql']['dir'] = '/etc/postgresql/9.6/main'
+    default['postgresql']['client']['packages'] = ['postgresql-client-9.6', 'libpq-dev']
+    default['postgresql']['server']['packages'] = ['postgresql-9.6']
+    default['postgresql']['contrib']['packages'] = ['postgresql-contrib-9.6']
   end
 
   default['postgresql']['server']['service_name'] = 'postgresql'


### PR DESCRIPTION
### Description

Set the default distribution version of postgresql to 9.6 for Debian 9+

### Issues Resolved

Resolve the issue #445 

### Contribution Check List

- [x ] All tests pass localy.