### PR TITLE
Fix RHEL inspecs tests for the repos

### DIFF
--- a/test/integration/repo/controls/repo_spec.rb.rb
+++ b/test/integration/repo/controls/repo_spec.rb.rb
@@ -4,19 +4,24 @@ case os[:family]
 
 when 'redhat'
 
-  describe yum.repo('pgdg10') do
-    it { should exist }
-    it { should_not be_enabled }
-  end
-
-  describe yum.repo('pgdg10-source') do
-    it { should exist }
-    it { should_not be_enabled }
-  end
-
-  describe yum.repo('pgdg10-updates-testing') do
+  describe yum.repo('pgdg9.5') do
     it { should exist }
     it { should be_enabled }
+  end
+
+  describe yum.repo('pgdg9.5-source') do
+    it { should exist }
+    it { should_not be_enabled }
+  end
+
+  describe yum.repo('pgdg9.5-source-updates-testing') do
+    it { should exist }
+    it { should_not be_enabled }
+  end
+
+  describe yum.repo('pgdg9.5-updates-testing') do
+    it { should exist }
+    it { should_not be_enabled }
   end
 
 when 'debian'


### PR DESCRIPTION
Update the tests for 9.5 and add the missing repo

Signed-off-by: Tim Smith <tsmith@chef.io>