### PR TITLE
Remove undefined method 'recursive'

### DIFF
--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -54,7 +54,6 @@ action :install do
 
   file "#{data_dir}/initialized.txt" do
     content   'Database initialized'
-    recursive true
     mode      '0744'
   end
 


### PR DESCRIPTION
### Description

resource `postgresql_server_install` raise error
```
         * postgresql_server_install[package] action install

           ================================================================================
           Error executing action `install` on resource 'postgresql_server_install[package]'
           ================================================================================

           NoMethodError
           -------------
           undefined method `recursive' for Chef::Resource::File

           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/postgresql/resources/server_install.rb:57:in `block (2 levels) in class_from_file'
           /tmp/kitchen/cache/cookbooks/postgresql/resources/server_install.rb:55:in `block in class_from_file'

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/mywrapper/recipes/_postgresql.rb

            20: postgresql_server_install 'package' do
            21:   version '9.4'
            22: end
            23:

           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/mywrapper/recipes/_postgresql.rb:20:in `from_file'

           postgresql_server_install("package") do
             action [:install]
             default_guard_interpreter :default
             declared_type :postgresql_server_install
             cookbook_name "mywrapper"
             recipe_name "_postgresql"
             version "9.4"
           end
```

Detected on Chef client  13.6.4.