### PR TITLE
Fix crash in server_install with no password

### DIFF
--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -77,7 +77,7 @@ action :install do
     echo "ALTER ROLE postgres ENCRYPTED PASSWORD \'#{postgres_password}\';" | psql -p #{new_resource.port}
     EOH
     not_if { ::File.exist? "#{data_dir}/recovery.conf" }
-    not_if { initialized }
+    not_if { initialized? }
     only_if { new_resource.password.eql? 'generate' }
   end
 end


### PR DESCRIPTION
### Description

Fixes typo causing:
```
[2018-01-18T09:33:06+00:00] DEBUG: NoMethodError: postgresql_server_install[Postgres Client and Server] (application_geocms::postgres line 10) had an error: NoMethodError: bash[generate-postgres-password] (/var/chef/cache/cookbooks/postgresql/resources/server_install.rb line 74) had an error: NoMethodError: undefined method `initialized' for Chef::Resource::Bash
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/resource.rb:1297:in `method_missing'
/var/chef/cache/cookbooks/postgresql/resources/server_install.rb:80:in `block (3 levels) in class_from_file'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/resource/conditional.rb:106:in `evaluate_block'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/resource/conditional.rb:95:in `evaluate'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/resource/conditional.rb:88:in `continue?'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/resource.rb:1439:in `block in should_skip?'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/resource.rb:1438:in `each'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/resource.rb:1438:in `find'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/resource.rb:1438:in `should_skip?'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/resource.rb:590:in `run_action'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/runner.rb:70:in `run_action'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/runner.rb:98:in `block (2 levels) in converge'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/runner.rb:98:in `each'
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/runner.rb:98:in `block in converge'
... etc
```

when no password declared in postgres_server_install (using chef-solo but not relevant):
```ruby
  postgresql_server_install "Postgres Client and Server" do
    version "9.6"
  end
```

### Issues Resolved

N/A

### Contribution Check List

- [ ] All tests pass.
- [x] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable