### PR TITLE
Database resource should ignore blank template

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Name                | Types           | Description                             
 To install PostgreSQL server, set you own postgres password and set another service port.   
 ```
 postgresql_server_install 'My Postgresql Server install' do
-  password 'MyP4ssw0d
+  password 'MyP4ssw0d'
   port 5433
 end
 ```

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -29,7 +29,7 @@ action :create do
   createdb << " -U #{new_resource.user}" if new_resource.user
   createdb << " -E #{new_resource.encoding}" if new_resource.encoding
   createdb << " -l #{new_resource.locale}" if new_resource.locale
-  createdb << " -T #{new_resource.template}" if new_resource.template
+  createdb << " -T #{new_resource.template}" unless new_resource.template.empty?
   createdb << " -h #{new_resource.host}" if new_resource.host
   createdb << " -p #{new_resource.port}" if new_resource.port
   createdb << " -O #{new_resource.owner}" if new_resource.owner


### PR DESCRIPTION
The default template for the resource is a blank string and if it isn't overridden, it generates a syntax error in the query.