### PR TITLE
Add in a way to specify an older extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Name        | Types  | Description                                        | Defa
 ----------- | ------ | -------------------------------------------------- | ---------------- | ---------
 `database`  | String | Name of the database to install the extention into | Name of resource | yes
 `extention` | String | Name of the extention to install the database      | Name of resource | yes
+`old_version` | String | Older module name for new extension replacement. Appends FROM to extension query      | None | no
 
 #### Examples
 

--- a/resources/extension.rb
+++ b/resources/extension.rb
@@ -21,10 +21,13 @@
 
 property :database,  String, required: true
 property :extension, String, name_property: true
+property :old_version, String
 
 action :create do
+  create_query = "CREATE EXTENSION IF NOT EXISTS \"#{new_resource.extension}\""
+  create_query << " FROM \"#{new_resource.old_version}\"" if property_is_set?(:old_version)
   bash "CREATE EXTENSION #{new_resource.name}" do
-    code psql("CREATE EXTENSION IF NOT EXISTS \"#{new_resource.extension}\"")
+    code psql(create_query)
     user 'postgres'
     action :run
     not_if { slave? || extension_installed? }


### PR DESCRIPTION
### Description

Per [CREATE EXTENSION documentation](https://www.postgresql.org/docs/9.6/static/sql-createextension.html) this adds the optional FROM argument in CREATE EXTENSION if you are replacing an older extension with a new one. Ran across this issue when upgrading repmgr which requires you specify a FROM clause to replace the older extension.

Creating a test for this is tricky as I don't know of any 'old' extensions we could pre-seed into the database then replace.

### Issues Resolved

None

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable