### PR TITLE
Fix postgresql_access resource

### DIFF
--- a/resources/access.rb
+++ b/resources/access.rb
@@ -24,30 +24,24 @@ property :access_db,     String, required: true, default: 'all'
 property :access_user,   String, required: true, default: 'postgres'
 property :access_addr,   String, required: true
 property :access_method, String, required: true, default: 'ident'
-property :notification,  Symbol, required: true, default: :reload
 
 action :grant do
-  with_run_context :root do # ~FC037
-    edit_resource(:template, "#{conf_dir}/pg_hba.conf") do |new_resource|
+    template "#{conf_dir}/pg_hba.conf" do
       source new_resource.source
       cookbook new_resource.cookbook
       owner 'postgres'
       group 'postgres'
       mode '0600'
-      variables['pg_hba'] ||= {}
-      variables['pg_hba'][new_resource.name] = {
-        comment: new_resource.comment,
-        type: new_resource.access_type,
-        db: new_resource.access_db,
-        user: new_resource.access_user,
-        addr: new_resource.access_addr,
-        method: new_resource.access_method,
-      }
-      action :nothing
-      delayed_action :create
-      notifies new_resource.notification, postgresql_service
+      variables(
+        pg_hba: {
+          comment: new_resource.comment,
+          type: new_resource.access_type,
+          db: new_resource.access_db,
+          user: new_resource.access_user,
+          addr: new_resource.access_addr,
+          method: new_resource.access_method,
+      })
     end
-  end
 end
 
 action_class do

--- a/templates/default/pg_hba.conf.erb
+++ b/templates/default/pg_hba.conf.erb
@@ -25,13 +25,11 @@ host    all             all             ::1/128                 md5
 ###########
 # Other authentication configurations taken from chef node defaults:
 ###########
-<% @pg_hba.each do |k,v| -%>
-<% if v[:comment] -%>
-# <%= v[:comment] %>
+<% if @pg_hba[:comment] -%>
+# <%= @pg_hba[:comment] %>
 <% end -%>
-<% if v[:addr] %>
-<%= v[:type].ljust(7) %> <%= v[:db].ljust(15) %> <%= v[:user].ljust(15) %> <%= v[:addr].ljust(23) %> <%= v[:method] %>
+<% if @pg_hba[:addr] %>
+<%= @pg_hba[:type].ljust(7) %> <%= @pg_hba[:db].ljust(15) %> <%= @pg_hba[:user].ljust(15) %> <%= @pg_hba[:addr].ljust(23) %> <%= @pg_hba[:method] %>
 <% else %>
-<%= v[:type].ljust(7) %> <%= v[:db].ljust(15) %> <%= v[:user].ljust(15) %>                         <%= v[:method] %>
-<% end %>
+<%= @pg_hba[:type].ljust(7) %> <%= @pg_hba[:db].ljust(15) %> <%= @pg_hba[:user].ljust(15) %>                         <%= @pg_hba[:method] %>
 <% end %>

--- a/test/cookbooks/test/recipes/server_install.rb
+++ b/test/cookbooks/test/recipes/server_install.rb
@@ -13,6 +13,14 @@ postgresql_server_conf 'PostgreSQL Config' do
   notifies :reload, 'service[postgresql]'
 end
 
+postgresql_access 'testuser' do
+  access_type 'host'
+  access_db 'testdb'
+  access_user 'testuser'
+  access_addr '127.0.0.1/32'
+  access_method 'md5'
+end
+
 service 'postgresql' do
   service_name lazy { platform_service_name }
   supports restart: true, status: true, reload: true


### PR DESCRIPTION
### Description

`postgresql_access` is broken. No one resource manages pg_hba.conf except `postgresql_access` but it uses `edit_resource` to change nonexisting resource `template`. 

Please correct me where i'm wrong. Thanks.