### PR TITLE
Cleanup and separate server install actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,12 @@ end
 
 ### postgresql_server_install
 
-This resource install PostgreSQL client and server packages.
+This resource installs the PostgreSQL server
 
 #### Actions
 
 - `install` - (default) Install client and server packages
+- `create` - Initialize the database
 
 #### Properties
 
@@ -148,8 +149,13 @@ Name                | Types           | Description                             
 To install PostgreSQL server, set you own postgres password and set another service port.
 ```
 postgresql_server_install 'My Postgresql Server install' do
+  action :install
+end
+
+postgresql_server_install 'Setup my postgresql 9.5 server' do
   password 'MyP4ssw0d'
   port 5433
+  action :create
 end
 ```
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -17,7 +17,6 @@
 #
 
 property :version,           String, default: '9.6'
-property :init_db,           [true, false], default: true
 property :setup_repo,        [true, false], default: true
 property :hba_file,          String, default: lazy { "#{conf_dir}/main/pg_hba.conf" }
 property :ident_file,        String, default: lazy { "#{conf_dir}/main/pg_ident.conf" }
@@ -25,6 +24,8 @@ property :external_pid_file, String, default: lazy { "/var/run/postgresql/#{vers
 property :password,          [String, nil], default: 'generate'
 property :port,              [String, Integer], default: 5432
 property :initdb_locale,     String, default: 'UTF-8'
+
+default_action :install
 
 action :install do
   node.run_state['postgresql'] ||= {}
@@ -36,8 +37,10 @@ action :install do
   end
 
   package server_pkg_name
+end
 
-  if platform_family?('rhel', 'fedora', 'amazon') && new_resource.init_db && !initialized?
+action :create do
+  if platform_family?('rhel', 'fedora', 'amazon') && !initialized?
     db_command = rhel_init_db_command
     if db_command
       execute 'init_db' do


### PR DESCRIPTION
### Description

This PR separates the install action of the server_install resource into install and create to separate concerns and simplify things. I would like to ask @damacus and @tas50 if they agree with me wanting to do the following in this PR:

* Rename `server_install` to `server` so we get `postgresql_server` as a resource and `:install` as an action which semantically makes a lot more sense.
* Remove the client install from `server_install`
* Move or remove the database initialization code. If you want to keep it, maybe a `cluster` resource since that is the terminology postgres tooling uses (ever use clusterctl?)
* Push a few more action_class methods into helpers for easier testing (I started some tests in #503 )

I think ideally, this cookbook should help you install a postgres server and configure it in an elegant way and in a sort of future-proofy way if possible so we're not hard coding all the options. It should also ditch the notion of a global PG version as you can _technically_ have multiple copies and clusters of postgres installed. You could install a 9.6 cluster and a 10.0 cluster then setup replication between the two via `pg_logical`, but as this cookbook is currently written, that won't happen.

Right now these changes in the PR get 3 of the 9 platforms passing for server-install and the other 6 are getting issues caused by the config resource so I can address those in a separate PR. I still need to fix the `setup_repo` logic since it is missing here, but forced into the client resource.

### Issues Resolved

None

### Contribution Check List

- [ ] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable