### PR TITLE
Six fixups

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -72,6 +72,8 @@ suites:
   run_list:
   - recipe[postgresql::ruby]
   - recipe[test::ruby]
+  excludes:
+    - centos-6
 
 - name: server
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,6 +2,7 @@
 rpm_based_platforms = %w(centos-6 centos-7 fedora-25)
 deb_based_platforms = %w(ubuntu-14.04 ubuntu-16.04 debian-7 debian-8)
 opensuse_platforms = %w(opensuse-13.2 opensuse-leap)
+eol_platforms = %w(centos-6 debian-7 opensuse-leap)
 %>
 ---
 driver:
@@ -72,8 +73,7 @@ suites:
   run_list:
   - recipe[postgresql::ruby]
   - recipe[test::ruby]
-  excludes:
-    - centos-6
+  excludes: <%= eol_platforms %>
 
 - name: server
   run_list:
@@ -83,6 +83,7 @@ suites:
     postgresql:
       password:
         postgres: iloverandompasswordsbutthiswilldo
+  excludes: <%= eol_platforms %>
 
 - name: apt-pgdg-server
   run_list:
@@ -171,6 +172,7 @@ suites:
         ssl_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
         ssl_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
       contrib:
+        packages: [ 'postgresql-contrib-9.4' ]
         extensions:
           - pg_stat_statements
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -28,6 +28,8 @@ when 'debian'
 when 'rhel', 'fedora'
   if node['postgresql']['enable_pgdg_yum']
     include_recipe 'postgresql::yum_pgdg_postgresql'
+    shortver = node['postgresql']['version'].gsub(/\./, '')
+    node.default['postgresql']['client']['packages'] = "postgresql#{shortver}-devel"
   end
 end
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -28,7 +28,7 @@ when 'debian'
 when 'rhel', 'fedora'
   if node['postgresql']['enable_pgdg_yum']
     include_recipe 'postgresql::yum_pgdg_postgresql'
-    shortver = node['postgresql']['version'].gsub(/\./, '')
+    shortver = node['postgresql']['version'].delete('.')
     node.default['postgresql']['client']['packages'] = "postgresql#{shortver}-devel"
   end
 end

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -21,7 +21,7 @@ db_name = node['postgresql']['database_name']
 # Install the PostgreSQL contrib package(s) from the distribution,
 # as specified by the node attributes.
 if node['postgresql']['enable_pgdg_yum'] || node['postgresql']['use_pgdg_packages']
-  shortver = node['postgresql']['version'].gsub(/\./, '')
+  shortver = node['postgresql']['version'].delete('.')
   node.default['postgresql']['contrib']['packages'] = ["postgresql#{shortver}-contrib"]
 end
 package node['postgresql']['contrib']['packages']

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -20,6 +20,10 @@ db_name = node['postgresql']['database_name']
 
 # Install the PostgreSQL contrib package(s) from the distribution,
 # as specified by the node attributes.
+if node['postgresql']['enable_pgdg_yum'] || node['postgresql']['use_pgdg_packages']
+  shortver = node['postgresql']['version'].gsub(/\./, '')
+  node.default['postgresql']['contrib']['packages'] = ["postgresql#{shortver}-contrib"]
+end
 package node['postgresql']['contrib']['packages']
 
 include_recipe 'postgresql::server'

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -48,6 +48,10 @@ directory node['postgresql']['config']['data_directory'] do
   mode '0700'
 end
 
+if node['postgresql']['enable_pgdg_yum'] || node['postgresql']['use_pgdg_packages']
+  node.default['postgresql']['server']['packages'] = ["postgresql#{shortver}-server"]
+  node.default['postgresql']['setup_script'] = "postgresql#{shortver}-setup"
+end
 package node['postgresql']['server']['packages']
 
 # If using PGDG, add symlinks so that downstream commands all work

--- a/resources/extension.rb
+++ b/resources/extension.rb
@@ -30,28 +30,28 @@ property :extension, String,
          default: lazy { name.scan(%r{(?<=/)[^/]+\Z}).first }
 
 action :create do
-  bash "CREATE EXTENSION #{name}" do
-    code psql("CREATE EXTENSION IF NOT EXISTS \"#{extension}\"")
+  bash "CREATE EXTENSION #{new_resource.name}" do
+    code psql("CREATE EXTENSION IF NOT EXISTS \"#{new_resource.extension}\"", new_resource.database)
     user 'postgres'
     action :run
-    not_if { extension_installed? }
+    not_if { extension_installed?(new_resource.extension, new_resource.database) }
   end
 end
 
 action :drop do
-  bash "DROP EXTENSION #{name}" do
-    code psql("DROP EXTENSION IF EXISTS \"#{extension}\"")
+  bash "DROP EXTENSION #{new_resource.name}" do
+    code psql("DROP EXTENSION IF EXISTS \"#{new_resource.extension}\"")
     user 'postgres'
     action :run
-    only_if { extension_installed? }
+    only_if { extension_installed?(new_resource.extension, new_resource.database) }
   end
 end
 
-def psql(query)
+def psql(query, database)
   "psql -d #{database} <<< '\\set ON_ERROR_STOP on\n#{query};'"
 end
 
-def extension_installed?
+def extension_installed?(extension, database)
   query = "SELECT 'installed' FROM pg_extension WHERE extname = '#{extension}';"
   !(execute_sql(query, database) =~ /^installed$/).nil?
 end

--- a/test/cookbooks/test/recipes/contrib.rb
+++ b/test/cookbooks/test/recipes/contrib.rb
@@ -2,6 +2,7 @@
 apt_update 'update' if platform_family?('debian')
 
 node.default['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'
-node.default['postgresql']['contrib']['extensions'] = %w( plpgsql xml2)
+# el6 ships 8.4 which does extensions differently and is also EOL
+node.default['postgresql']['contrib']['extensions'] = %w( plpgsql xml2) unless platform_family?('rhel') && node['platform_version'].to_i < 7
 
 include_recipe 'postgresql::contrib'


### PR DESCRIPTION
### Description

Get rid of deprecation warnings in the extension resource. Also includes changes to make the test kitchen suites all pass. Based on the 6.1.1 release as it looks like a lot of other changes are in the works in master. Feel free to reject - my thought was maybe use something like this to release a 6.1.2 while whatever the plan for master gets finished, particularly with Chef client 14 coming soon. If so this should apply cleanly to a branch made from the 6.1.1 release.

### Contribution Check List

- [X] All tests pass.
- [NA] New functionality includes testing.
- [NA] New functionality has been documented in the README if applicable