### PR TITLE
Fix for wrapper cookbooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Name            | Types       | Description                                     
 --------------- | ----------- | ----------------------------------------------------------------------------------------- | ----------------- | ---------
 `name`          | String      | Name of the access resource, this is left as a comment inside the `pg_hba` config         | Resource name     | yes
 `source`        | String      | The cookbook template filename if you want to use your own custom template                | 'pg_hba.conf.erb' | yes
-`cookbook`      | String      | The cookbook to look in for the template source                                           | 'postgresql'      | yes
+`cookbook_name` | String      | The cookbook to look in for the template source                                           | 'postgresql'      | yes
 `comment`       | String, nil | A comment to leave above the entry in `pg_hba`                                            | nil               | no
 `access_type`   | String      | The type of access, e.g. local or host                                                    | 'local'           | yes
 `access_db`     | String      | The database to access. Can use 'all' for all databases                                   | 'all'             | yes

--- a/resources/access.rb
+++ b/resources/access.rb
@@ -43,7 +43,7 @@ action :grant do
         addr: new_resource.access_addr,
         method: new_resource.access_method,
       }
-      action :nothing
+      action :create
       notifies new_resource.notification, postgresql_service, :immediately
     end
   end

--- a/resources/access.rb
+++ b/resources/access.rb
@@ -44,8 +44,7 @@ action :grant do
         method: new_resource.access_method,
       }
       action :nothing
-      delayed_action :create
-      notifies new_resource.notification, postgresql_service
+      notifies new_resource.notification, postgresql_service, :immediately
     end
   end
 end

--- a/resources/access.rb
+++ b/resources/access.rb
@@ -17,7 +17,7 @@
 #
 
 property :source,        String, required: true, default: 'pg_hba.conf.erb'
-property :cookbook,      String, default: 'postgresql'
+property :cookbook_name, String, default: 'postgresql'
 property :comment,       [String, nil], default: nil
 property :access_type,   String, required: true, default: 'local'
 property :access_db,     String, required: true, default: 'all'
@@ -30,7 +30,7 @@ action :grant do
   with_run_context :root do # ~FC037
     edit_resource(:template, "#{conf_dir}/pg_hba.conf") do |new_resource|
       source new_resource.source
-      cookbook new_resource.cookbook
+      cookbook new_resource.cookbook_name
       owner 'postgres'
       group 'postgres'
       mode '0600'

--- a/resources/ident.rb
+++ b/resources/ident.rb
@@ -41,7 +41,7 @@ action :create do
       }
       action :nothing
       delayed_action :create
-      notifies new_resource.notification, postgresql_service
+      notifies new_resource.notification, postgresql_service, :immediately
     end
   end
 end

--- a/resources/ident.rb
+++ b/resources/ident.rb
@@ -18,7 +18,7 @@
 
 property :mapname,       String, required: true, name_property: true
 property :source,        String, required: true, default: 'pg_ident.conf.erb'
-property :cookbook,      String, default: 'postgresql'
+property :cookbook_name, String, default: 'postgresql'
 property :system_user,   String, required: true
 property :pg_user,       String, required: true
 property :comment,       [String, nil], default: nil
@@ -28,7 +28,7 @@ action :create do
   with_run_context :root do # ~FC037
     edit_resource(:template, "#{conf_dir}/pg_ident.conf") do |new_resource|
       source new_resource.source
-      cookbook new_resource.cookbook
+      cookbook new_resource.cookbook_name
       owner 'postgres'
       group 'postgres'
       mode '0640'
@@ -39,8 +39,7 @@ action :create do
         system_user: new_resource.system_user,
         pg_user: new_resource.pg_user,
       }
-      action :nothing
-      delayed_action :create
+      action :create
       notifies new_resource.notification, postgresql_service, :immediately
     end
   end

--- a/resources/server_conf.rb
+++ b/resources/server_conf.rb
@@ -38,7 +38,7 @@ action :modify do
       external_pid_file: new_resource.external_pid_file,
       stats_temp_directory: new_resource.stats_temp_directory
     )
-    notifies new_resource.notification, postgresql_service
+    notifies new_resource.notification, postgresql_service, :immediately
   end
 end
 


### PR DESCRIPTION
### Description

This change is required in case you have a wrapper cookbook for one service that requires a postgresql server configured with access. 

### Issues Resolved

If you have a service in your wrapper cookbook that requires postgresql server and configuration to be up and running, the delayed_action and the :delayed notification will make postgresql to reload after your service starts, making it fail.

If the property name for postgresql_access is called 'cookbook', chef 12.21.26 (the one i tested), will not find the template required for that specific resource, because it's looking at that in the wrapper cookbook.