### PR TITLE
Add in deprecation warnings for ALL THE THINGS!

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Installs and configures PostgreSQL as a client or a server.
 
+## DEPRECATION NOTICE!!!
+
+There will be an upcoming major version which migrates to a resource based cookbook and _all_ recipes will be removed! You will want to version pin to 6.1.1 to prevent major breaking changes. See the README in the postgresql cookbook repo for migration details.
+
 ## Requirements
 
 ### Platforms

--- a/recipes/apt_pgdg_postgresql.rb
+++ b/recipes/apt_pgdg_postgresql.rb
@@ -1,3 +1,5 @@
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 # frozen_string_literal: true
 apt_repository 'apt.postgresql.org' do
   uri 'http://apt.postgresql.org/pub/repos/apt'

--- a/recipes/ca_certificates.rb
+++ b/recipes/ca_certificates.rb
@@ -1,2 +1,4 @@
 # frozen_string_literal: true
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 Chef::Log.warn('The postgresql::ca-certificates recipe has been deprecated and will be removed in the next major release of the cookbook')

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 case node['platform_family']
 when 'debian'
   if node['postgresql']['version'].to_f > 9.3

--- a/recipes/config_initdb.rb
+++ b/recipes/config_initdb.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
 
 #######
 # Load the locale_date_order() and select_default_timezone(tzdir)

--- a/recipes/config_pgtune.rb
+++ b/recipes/config_pgtune.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 #######
 # Load the binaryround(value) method from libraries/default.rb
 ::Chef::Recipe.send(:include, Opscode::PostgresqlHelpers)

--- a/recipes/contrib.rb
+++ b/recipes/contrib.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 db_name = node['postgresql']['database_name']
 
 # Install the PostgreSQL contrib package(s) from the distribution,

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 # Load the pgdgrepo_rpm_info method from libraries/default.rb
 ::Chef::Recipe.send(:include, Opscode::PostgresqlHelpers)
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 ::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
 
 include_recipe 'postgresql::client'

--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 change_notify = node['postgresql']['server']['config_change_notify']
 
 # There are some configuration items which depend on correctly evaluating the intended version being installed

--- a/recipes/server_debian.rb
+++ b/recipes/server_debian.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 include_recipe 'postgresql::client'
 
 package node['postgresql']['server']['packages']

--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 include_recipe 'postgresql::client'
 
 svc_name = node['postgresql']['server']['service_name']

--- a/recipes/yum_pgdg_postgresql.rb
+++ b/recipes/yum_pgdg_postgresql.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+Chef::Log.warn 'This cookbook is being re-written to use resources, not recipes and will only be Chef 13.8+ compatible. Please version pin to 6.1.1 to prevent the breaking changes from taking effect. See https://github.com/sous-chefs/postgresql/issues/512 for details'
+
 ######################################
 # Install the "PostgreSQL RPM Building Project - Yum Repository"
 


### PR DESCRIPTION
### Description

This jams in a few deprecation warnings to let users of the 6.x series cookbook know they will need to version pin to avoid lots of breakage.

### Issues Resolved

- #512 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable