### PR TITLE
Updates to port usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Name                | Types             | Description                           
 `ident_file`        | String            |                                                               | `#{conf_dir}/main/pg_ident.conf`          | no
 `external_pid_file` | String            |                                                               | `/var/run/postgresql/#{version}-main.pid` | no
 `password`          | String, nil       | Pass in a password, or have the cookbook generate one for you | 'generate'                                | no
-`port`              | [String, Integer] | Database listen port                                          | 5432                                      | no
 `initdb_locale`     | String            | Locale to initialise the database with                        | 'C'                                       | no
 
 #### Examples
@@ -87,11 +86,11 @@ Name                | Types           | Description                             
 `ident_file`        | String          | Path of pg_ident.conf file                    | `<default_os_path>/pg_ident.conf`                  | no
 `external_pid_file` | String          | Path of PID file                              | `/var/run/postgresql/<version>-main.pid</version>` | no
 `password`          | String, nil     | Set postgresql user password                  | 'generate'                                         | no
-`port`              | String, Integer | Set listen port of postgresql service         | 5432                                               | no
+`port`              | Integer         | Set listen port of postgresql service         | 5432                                               | no
 
 #### Examples
 
-To install PostgreSQL server, set you own postgres password and set another service port.
+To install PostgreSQL server, set you own postgres password using non-default service port.
 
 ```
 postgresql_server_install 'My Postgresql Server install' do
@@ -115,15 +114,16 @@ This resource manages postgresql.conf configuration file.
 
 #### Properties
 
-Name                   | Types  | Description                             | Default                                             | Required?
----------------------- | ------ | --------------------------------------- | --------------------------------------------------- | ---------
-`version`              | String | Version of PostgreSQL to install        | '9.6'                                               | no
-`data_directory`       | String | Path of postgresql data directory       | `<default_os_data_path>`                            | no
-`hba_file`             | String | Path of pg_hba.conf file                | `<default_os_conf_path>/pg_hba.conf`                | no
-`ident_file`           | String | Path of pg_ident.conf file              | `<default_os_conf_path>/pg_ident.conf`              | no
-`external_pid_file`    | String | Path of PID file                        | `/var/run/postgresql/<postgresql_version>-main.pid` | no
-`stats_temp_directory` | String | Path of stats file                      | `/var/run/postgresql/version>-main.pg_stat_tmp`     | no
-`additional_config`    | Hash   | Extra configuration for the config file | {}                                                  | no
+Name                   | Types   | Description                             | Default                                             | Required?
+---------------------- | ------- | --------------------------------------- | --------------------------------------------------- | ---------
+`version`              | String  | Version of PostgreSQL to install        | '9.6'                                               | no
+`data_directory`       | String  | Path of postgresql data directory       | `<default_os_data_path>`                            | no
+`hba_file`             | String  | Path of pg_hba.conf file                | `<default_os_conf_path>/pg_hba.conf`                | no
+`ident_file`           | String  | Path of pg_ident.conf file              | `<default_os_conf_path>/pg_ident.conf`              | no
+`external_pid_file`    | String  | Path of PID file                        | `/var/run/postgresql/<postgresql_version>-main.pid` | no
+`stats_temp_directory` | String  | Path of stats file                      | `/var/run/postgresql/version>-main.pg_stat_tmp`     | no
+`port`                 | Integer | Set listen port of postgresql service   | 5432                                                | no
+`additional_config`    | Hash    | Extra configuration for the config file | {}                                                  | no
 
 #### Examples
 

--- a/resources/server_conf.rb
+++ b/resources/server_conf.rb
@@ -24,6 +24,7 @@ property :hba_file,             String, default: lazy { "#{conf_dir}/pg_hba.conf
 property :ident_file,           String, default: lazy { "#{conf_dir}/pg_ident.conf" }
 property :external_pid_file,    String, default: lazy { "/var/run/postgresql/#{version}-main.pid" }
 property :stats_temp_directory, String, default: lazy { "/var/run/postgresql/#{version}-main.pg_stat_tmp" }
+property :port,                 Integer, default: 5432
 property :additional_config,    Hash,   default: {}
 property :cookbook,             String, default: 'postgresql'
 
@@ -40,6 +41,7 @@ action :modify do
       ident_file: new_resource.ident_file,
       external_pid_file: new_resource.external_pid_file,
       stats_temp_directory: new_resource.stats_temp_directory,
+      port: new_resource.port,
       additional_config: new_resource.additional_config
     )
   end

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -24,14 +24,13 @@ property :hba_file,          String, default: lazy { "#{conf_dir}/main/pg_hba.co
 property :ident_file,        String, default: lazy { "#{conf_dir}/main/pg_ident.conf" }
 property :external_pid_file, String, default: lazy { "/var/run/postgresql/#{version}-main.pid" }
 property :password,          [String, nil], default: 'generate' # Set to nil if we do not want to set a password
-property :port,              [String, Integer], default: 5432
+property :port,              Integer, default: 5432
 property :initdb_locale,     String
 
-# Connection prefernces
+# Connection preferences
 property :user,     String, default: 'postgres'
 property :database, String
 property :host,     [String, nil]
-property :port,     Integer, default: 5432
 
 action :install do
   node.run_state['postgresql'] ||= {}

--- a/templates/postgresql.conf.erb
+++ b/templates/postgresql.conf.erb
@@ -8,6 +8,7 @@ hba_file = '<%= @hba_file %>'
 ident_file = '<%= @ident_file %>'
 external_pid_file = '<%= @external_pid_file %>'
 stats_temp_directory = '<%= @stats_temp_directory %>'
+port = <%= @port %>
 <% @additional_config.sort.each do |key, value| %>
 <% next if value.nil? -%>
 <%= key %> = <%=


### PR DESCRIPTION
### Description
Updates to `port` usage.

**server_install**
- Removed duplicate `port` property.
- Changed `port` to only be an Integer.
- Fixed typo in word "preferences".

**server_conf**
- Added `port` as a property in **server_conf** as Integer and default 5432.
- Set `port` as a variable that gets passed to **postgresql.conf.erb**.
- Added `port` as something that gets added via **postgresql.conf.erb**.

_I found that changing `port` in server_install doesn't actually update the postgresql.conf file (it's mostly for the helper library when `psql_command_string` gets called). Using only **server_install** results in the default postgresql.conf file (aka 5432). You need to you need to use **server_conf** if you want another port. Users could set `port` in the `additional_config` hash, but to be consistant with all the other resources I think it would make sense that port is also a value that can be set in the **server config**._

**README**
- Removed the `port` property from **client_install** since it isn't valid value.
- Changed `port` to only be Integer for **server_install** and updated Example verbage.
- Added `port` to **server_conf** to make it clearer that this is how you actually change the listening port. 

### Issues Resolved

Didn't open one, let me know if I should.

### Contribution Check List

- [x] New functionality has been documented in the README if applicable