### PR TITLE
Updated default version to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This resource installs PostgreSQL client packages.
 
 Name                | Types             | Description                                                   | Default                                   | Required?
 ------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
-`version`           | String            | Version of PostgreSQL to install                              | '9.6'                                     | no
+`version`           | String            | Version of PostgreSQL to install                              | '10'                                      | no
 `setup_repo`        | Boolean           | Define if you want to add the PostgreSQL repo                 | true                                      | no
 `hba_file`          | String            |                                                               | `#{conf_dir}/main/pg_hba.conf`            | no
 `ident_file`        | String            |                                                               | `#{conf_dir}/main/pg_ident.conf`          | no
@@ -59,11 +59,11 @@ Name                | Types             | Description                           
 
 #### Examples
 
-To install '9.5' version:
+To install '9.6' version:
 
 ```
 postgresql_client_install 'My Postgresql Client install' do
-  version '9.5'
+  version '9.6'
 end
 ```
 
@@ -80,7 +80,7 @@ This resource installs PostgreSQL client and server packages.
 
 Name                | Types           | Description                                   | Default                                            | Required?
 ------------------- | --------------- | --------------------------------------------- | -------------------------------------------------- | ---------
-`version`           | String          | Version of PostgreSQL to install              | '9.6'                                              | no
+`version`           | String          | Version of PostgreSQL to install              | '10'                                               | no
 `setup_repo`        | Boolean         | Define if you want to add the PostgreSQL repo | true                                               | no
 `hba_file`          | String          | Path of pg_hba.conf file                      | `<default_os_path>/pg_hba.conf'`                   | no
 `ident_file`        | String          | Path of pg_ident.conf file                    | `<default_os_path>/pg_ident.conf`                  | no
@@ -97,7 +97,7 @@ postgresql_server_install 'My Postgresql Server install' do
   action :install
 end
 
-postgresql_server_install 'Setup my postgresql 9.5 server' do
+postgresql_server_install 'Setup my postgresql 10 server' do
   password 'MyP4ssw0d'
   port 5433
   action :create
@@ -116,7 +116,7 @@ This resource manages postgresql.conf configuration file.
 
 Name                   | Types   | Description                             | Default                                             | Required?
 ---------------------- | ------- | --------------------------------------- | --------------------------------------------------- | ---------
-`version`              | String  | Version of PostgreSQL to install        | '9.6'                                               | no
+`version`              | String  | Version of PostgreSQL to install        | '10'                                                | no
 `data_directory`       | String  | Path of postgresql data directory       | `<default_os_data_path>`                            | no
 `hba_file`             | String  | Path of pg_hba.conf file                | `<default_os_conf_path>/pg_hba.conf`                | no
 `ident_file`           | String  | Path of pg_ident.conf file              | `<default_os_conf_path>/pg_ident.conf`              | no
@@ -131,8 +131,8 @@ To setup your PostgreSQL configuration with a specific data directory. If you ha
 
 ```
 postgresql_server_conf 'My PostgreSQL Config' do
-  version '9.5'
-  data_directory '/data/postgresql/9.5/main'
+  version '9.6'
+  data_directory '/data/postgresql/9.6/main'
   notification :reload
 end
 ```
@@ -160,7 +160,7 @@ To install the `adminpack` extension:
 
 ```ruby
 # Add the contrib package in Ubuntu/Debian
-package 'postgresql-contrib-9.6'
+package 'postgresql-contrib-10'
 
 # Install adminpack extension
 postgresql_extension 'postgres adminpack' do
@@ -365,11 +365,11 @@ Example: cookbooks/my_postgresql/recipes/default.rb
 ```ruby
 postgresql_client_install 'Postgresql Client' do
   setup_repo false
-  version '9.5'
+  version '10'
 end
 
 postgresql_server_install 'Postgresql Server' do
-  version '9.5'
+  version '10'
   setup_repo false
   password 'P0sgresP4ssword'
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -206,7 +206,7 @@ module PostgresqlCookbook
 
     # determine the appropriate DB init command to run based on RHEL/Fedora/Amazon release
     # initdb defaults to the execution environment.
-    # https://www.postgresql.org/docs/9.5/static/locale.html
+    # https://www.postgresql.org/docs/10/static/locale.html
     def rhel_init_db_command(new_resource)
       cmd = "/usr/pgsql-#{new_resource.version}/bin/initdb"
       cmd << " --locale '#{new_resource.initdb_locale}'" if new_resource.initdb_locale

--- a/resources/client_install.rb
+++ b/resources/client_install.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-property :version,    String, default: '9.6'
+property :version,    String, default: '10'
 property :setup_repo, [true, false], default: true
 
 action :install do

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-property :version,                            String, default: '9.6'
+property :version,                            String, default: '10'
 property :enable_pgdg,                        [true, false], default: true
 property :enable_pgdg_source,                 [true, false], default: false
 property :enable_pgdg_updates_testing,        [true, false], default: false

--- a/resources/server_conf.rb
+++ b/resources/server_conf.rb
@@ -18,7 +18,7 @@
 
 include PostgresqlCookbook::Helpers
 
-property :version,              String, default: '9.6'
+property :version,              String, default: '10'
 property :data_directory,       String, default: lazy { data_dir }
 property :hba_file,             String, default: lazy { "#{conf_dir}/pg_hba.conf" }
 property :ident_file,           String, default: lazy { "#{conf_dir}/pg_ident.conf" }

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -18,7 +18,7 @@
 
 include PostgresqlCookbook::Helpers
 
-property :version,           String, default: '9.6'
+property :version,           String, default: '10'
 property :setup_repo,        [true, false], default: true
 property :hba_file,          String, default: lazy { "#{conf_dir}/main/pg_hba.conf" }
 property :ident_file,        String, default: lazy { "#{conf_dir}/main/pg_ident.conf" }

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -12,21 +12,21 @@ RSpec.describe PostgresqlCookbook::Helpers do
       allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
     end
 
-    let(:pg_version) { '9.6' }
+    let(:pg_version) { '10' }
 
-    context 'with rhel family and Postgres 9.6' do
+    context 'with rhel family and Postgres 10' do
       let(:platform_family) { 'rhel' }
 
       it 'returns the correct path' do
-        expect(subject.data_dir(pg_version)).to eq '/var/lib/pgsql/9.6/data'
+        expect(subject.data_dir(pg_version)).to eq '/var/lib/pgsql/10/data'
       end
     end
 
-    context 'with debian family and Postgres 9.6' do
+    context 'with debian family and Postgres 10' do
       let(:platform_family) { 'debian' }
 
       it 'returns the correct path' do
-        expect(subject.data_dir(pg_version)).to eq '/var/lib/postgresql/9.6/main'
+        expect(subject.data_dir(pg_version)).to eq '/var/lib/postgresql/10/main'
       end
     end
   end
@@ -36,21 +36,21 @@ RSpec.describe PostgresqlCookbook::Helpers do
       allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
     end
 
-    let(:pg_version) { '9.6' }
+    let(:pg_version) { '10' }
 
-    context 'with rhel family and Postgres 9.6' do
+    context 'with rhel family and Postgres 10' do
       let(:platform_family) { 'rhel' }
 
       it 'returns the correct path' do
-        expect(subject.conf_dir(pg_version)).to eq '/var/lib/pgsql/9.6/data'
+        expect(subject.conf_dir(pg_version)).to eq '/var/lib/pgsql/10/data'
       end
     end
 
-    context 'with debian family and Postgres 9.6' do
+    context 'with debian family and Postgres 10' do
       let(:platform_family) { 'debian' }
 
       it 'returns the correct path' do
-        expect(subject.conf_dir(pg_version)).to eq '/etc/postgresql/9.6/main'
+        expect(subject.conf_dir(pg_version)).to eq '/etc/postgresql/10/main'
       end
     end
   end
@@ -60,17 +60,17 @@ RSpec.describe PostgresqlCookbook::Helpers do
       allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
     end
 
-    let(:pg_version) { '9.6' }
+    let(:pg_version) { '10' }
 
-    context 'with rhel family and Postgres 9.6' do
+    context 'with rhel family and Postgres 10' do
       let(:platform_family) { 'rhel' }
 
       it 'returns the correct service name' do
-        expect(subject.platform_service_name(pg_version)).to eq 'postgresql-9.6'
+        expect(subject.platform_service_name(pg_version)).to eq 'postgresql-10'
       end
     end
 
-    context 'with debian family and Postgres 9.6' do
+    context 'with debian family and Postgres 10' do
       let(:platform_family) { 'debian' }
 
       it 'returns the correct service name' do
@@ -172,7 +172,7 @@ RSpec.describe PostgresqlCookbook::Helpers do
   describe '#alter_role_sql' do
     it 'should return a correct SQL string to set a password' do
       new_resource = double(
-        version: '9.6',
+        version: '10',
         setup_repo: true,
         hba_file: nil,
         ident_file: nil,

--- a/test/cookbooks/test/recipes/client_install.rb
+++ b/test/cookbooks/test/recipes/client_install.rb
@@ -1,4 +1,4 @@
 # This resource should install the postgresql client
 postgresql_client_install 'postgresql client' do
-  version '9.5'
+  version '10'
 end

--- a/test/cookbooks/test/recipes/repository.rb
+++ b/test/cookbooks/test/recipes/repository.rb
@@ -1,3 +1,3 @@
 postgresql_repository 'pg repo' do
-  version '9.5'
+  version '10'
 end

--- a/test/integration/repo/controls/repo_spec.rb.rb
+++ b/test/integration/repo/controls/repo_spec.rb.rb
@@ -4,22 +4,22 @@ case os[:family]
 
 when 'redhat'
 
-  describe yum.repo('pgdg9.5') do
+  describe yum.repo('pgdg10') do
     it { should exist }
     it { should be_enabled }
   end
 
-  describe yum.repo('pgdg9.5-source') do
+  describe yum.repo('pgdg10-source') do
     it { should exist }
     it { should_not be_enabled }
   end
 
-  describe yum.repo('pgdg9.5-source-updates-testing') do
+  describe yum.repo('pgdg10-source-updates-testing') do
     it { should exist }
     it { should_not be_enabled }
   end
 
-  describe yum.repo('pgdg9.5-updates-testing') do
+  describe yum.repo('pgdg10-updates-testing') do
     it { should exist }
     it { should_not be_enabled }
   end

--- a/test/integration/server_install/controls/server_spec.rb
+++ b/test/integration/server_install/controls/server_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if os[:family] == 'redhat' || os[:family] == 'fedora'
-  describe service('postgresql-9.6') do
+  describe service('postgresql-10') do
     it { should be_installed }
     it { should be_enabled }
     it { should be_running }


### PR DESCRIPTION
### Description

Changed default version to 10

### Issues Resolved

N/A

### Contribution Check List

- [Sadly not] All tests pass.
```RUST_BACKTRACE=1 delivery local all
Chef Delivery
Running Every Stage
Running Lint Phase
Inspecting 28 files
............................

28 files inspected, no offenses detected
Running Syntax Phase
Checking 16 files
................

Running Unit Phase
thread 'main' panicked at 'Unexpected error: Failed to execute process: No such file or directory (os error 2)', src/delivery/command/local.rs:87
stack backtrace:
   1:        0x10bed861a - std::sys::imp::backtrace::tracing::imp::write::hd3b65cdfe843284c
   2:        0x10bede32f - std::panicking::default_hook::{{closure}}::hf2b7428652613d83
   3:        0x10beddfd7 - std::panicking::default_hook::h5da8f27db5582938
   4:        0x10bede7f6 - std::panicking::rust_panic_with_hook::hcef1e67c646c6802
   5:        0x10bede694 - std::panicking::begin_panic::hc2e8ca89533cd10d
   6:        0x10bede5b2 - std::panicking::begin_panic_fmt::h60990696c3c3a88d
   7:        0x10bdba9ff - delivery::command::local::exec_phase::h89c5840e946fbf7a
   8:        0x10bdb9db7 - <delivery::command::local::LocalCommand<'n> as delivery::command::Command>::run::h21254cfa6df22849
   9:        0x10bd22ba8 - std::panicking::try::do_call::h1e7b36d4a8b77817
  10:        0x10bedf6aa - __rust_maybe_catch_panic
  11:        0x10bda46f8 - delivery::cli::match_command_and_start::h1f63fa6d7c9db1bf
  12:        0x10bda1f9e - delivery::cli::run::h0f6a887377a571f8
  13:        0x10bedf6aa - __rust_maybe_catch_panic
  14:        0x10bedeb96 - std::rt::lang_start::h87cb84a8b6cb187e
```
- [N/A] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
