### PR TITLE
Fix HBA Order

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures postgresql for clients or servers'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '7.1.0'
+version           '7.1.1'
 source_url        'https://github.com/sous-chefs/postgresql'
 issues_url        'https://github.com/sous-chefs/postgresql/issues'
 chef_version      '>= 13.8'

--- a/templates/pg_hba.conf.erb
+++ b/templates/pg_hba.conf.erb
@@ -6,20 +6,10 @@
 # Refer to the "Client Authentication" section in the PostgreSQL
 # documentation for a complete description of this file.
 
-local   all             postgres                                peer
-
-# TYPE  DATABASE        USER            ADDRESS                 METHOD
-
-# "local" is for Unix domain socket connections only
-local   all             all                                     peer
-# IPv4 local connections:
-host    all             all             127.0.0.1/32            md5
-# IPv6 local connections:
-host    all             all             ::1/128                 md5
-
 ###########
 # From the postgresql_access resources
 ###########
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
 <% @pg_hba.each do |k,v| -%>
 # <%= k %>
 <% if v[:comment] -%>
@@ -31,3 +21,16 @@ host    all             all             ::1/128                 md5
 <%= v[:type].ljust(7) %> <%= v[:db].ljust(15) %> <%= v[:user].ljust(15) %>                         <%= v[:method] %>
 <% end %>
 <% end %>
+
+############
+# Defaults from postgresql cookbook
+############
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+# Local postgres user can access postgres account
+local   all             postgres                                peer
+# Local users can access accounts with their username
+local   all             all                                     peer
+# IPv4 local connections (use password)
+host    all             all             127.0.0.1/32            md5
+# IPv6 local connections (use password)
+host    all             all             ::1/128                 md5


### PR DESCRIPTION
### Description

Fixes order of HBA file

### Issues Resolved

Allows users configuration to be read first, so that they are the rules used first (pg_hba.conf is read in order)

### Contribution Check List

- [X] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable

I don't think this needs updated documentation nor tests, as this just does the correct thing and has the defaults last instead of first (which causes the user to not be able to modify those settings).