### PR TITLE
Fix setup postgresql extenstion

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -71,7 +71,7 @@ module PostgresqlCookbook
       if new_resource.version
         version_result.stdout == new_resource.version
       else
-        !version_result.stdout.nil?
+        !version_result.stdout.eql?("\n")
       end
     end
 

--- a/test/cookbooks/test/recipes/extension.rb
+++ b/test/cookbooks/test/recipes/extension.rb
@@ -2,11 +2,11 @@ postgresql_repository 'install'
 
 postgresql_server_install 'package' do
   action [:install, :create]
-  initdb_locale 'en_US.utf8'
+  initdb_locale 'en_US.UTF-8'
 end
 
 postgresql_database 'test_1' do
-  locale 'en_US.utf8'
+  locale 'en_US.UTF-8'
 end
 
 package 'postgresql-contrib'

--- a/test/cookbooks/test/recipes/extension.rb
+++ b/test/cookbooks/test/recipes/extension.rb
@@ -1,3 +1,5 @@
+# recipes/extension.rb
+
 postgresql_repository 'install'
 
 postgresql_server_install 'package' do


### PR DESCRIPTION
Hey,

current `postgresql_extension` skips installing extension because `shell_out` returns string "\n" for the absent extension instead of nil.

This PR fixes this issue.