### PR TITLE
Update example usage [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,20 +366,20 @@ To install and configure your PostgreSQL instance you need to create your own co
 
 More examples can be found in `test/cookbooks/test/recipes`
 
-## Example Useage
-
-Example: cookbooks/my_postgresql/recipes/default.rb
+## Example Usage
 
 ```ruby
+# cookbooks/my_postgresql/recipes/default.rb
+
 postgresql_client_install 'PostgreSQL Client' do
   setup_repo false
-  version '9.5'
+  version '10.6'
 end
 
 postgresql_server_install 'PostgreSQL Server' do
-  version '9.5'
+  version '10.6'
   setup_repo false
-  password 'P0sgresP4ssword'
+  password 'P0stgresP4ssword'
 end
 
 postgresql_server_conf 'PostgreSQL Config' do


### PR DESCRIPTION
10.6 is not the latest, but I haven't tested this cookbook with 11 yet so I don't wanna use it in the example just yet.

Also corrected a typo in the header and added a "t" to the sample password.