### PR TITLE
make postgres.conf world readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in the last 3 major versions of the postg
 ## v7.1.2 (Unreleased)
 
 - Cleanup and update the user resource documentation and code. Removed extraneous 'sensitive' property which is a common property in all Chef resources.
+- Change default permissions on the postgres.conf to be world readable so that psql can work.
 
 ## v7.1.1 (26-09-2018)
 

--- a/resources/server_conf.rb
+++ b/resources/server_conf.rb
@@ -34,7 +34,7 @@ action :modify do
     source 'postgresql.conf.erb'
     owner 'postgres'
     group 'postgres'
-    mode '0600'
+    mode '0644'
     variables(
       data_dir: new_resource.data_directory,
       hba_file: new_resource.hba_file,


### PR DESCRIPTION
### Description

Allows users to access postgres with psql locally

### Issues Resolved

#588 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable