### PR TITLE
Escape username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 - Cleanup and update the user resource documentation and code. Removed extraneous 'sensitive' property which is a common property in all Chef resources.
 - Change default permissions on the postgres.conf to be world readable so that psql can work.
+- Added support for dash in database role name.
 
 ## v7.1.1 (26-09-2018)
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -96,7 +96,7 @@ module PostgresqlCookbook
     end
 
     def role_sql(new_resource)
-      sql = %(#{new_resource.create_user} WITH )
+      sql = %(\\"#{new_resource.create_user}\\" WITH )
 
       %w(superuser createdb createrole inherit replication login).each do |perm|
         sql << "#{'NO' unless new_resource.send(perm)}#{perm.upcase} "

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe PostgresqlCookbook::Helpers do
         encrypted_password: nil,
         valid_until: nil
       )
-      result = %(sous_chef WITH SUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION LOGIN PASSWORD '67890')
+      result = %(\\"sous_chef\\" WITH SUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION LOGIN PASSWORD '67890')
 
       expect(subject.role_sql(new_resource)).to eq result
     end

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -29,6 +29,10 @@ postgresql_access 'a sous_chef local superuser' do
   notifies :reload, 'service[postgresql]'
 end
 
+postgresql_user 'name-with-dash' do
+  password '1234'
+end
+
 service 'postgresql' do
   extend PostgresqlCookbook::Helpers
   service_name lazy { platform_service_name }

--- a/test/integration/access/controls/base_access.rb
+++ b/test/integration/access/controls/base_access.rb
@@ -44,3 +44,14 @@ control 'sous_chef role should exist' do
     its('output') { should cmp /sous_chef/ }
   end
 end
+
+control 'name-with-dash role should exist' do
+  impact 1.0
+  desc 'The name-with-dash database user role should exist'
+
+  postgres_access = postgres_session('postgres', '12345', '127.0.0.1')
+
+  describe postgres_access.query('SELECT rolname FROM pg_roles;') do
+    its('output') { should cmp /name-with-dash/ }
+  end
+end


### PR DESCRIPTION
### Description

Escape username so we can use username with dash

### Issues Resolved

Closes: https://github.com/sous-chefs/postgresql/issues/583

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable