### PR TITLE
Update documentation about generating passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Name                | Types             | Description                           
 `hba_file`          | String            |                                                               | `#{conf_dir}/main/pg_hba.conf`            | no
 `ident_file`        | String            |                                                               | `#{conf_dir}/main/pg_ident.conf`          | no
 `external_pid_file` | String            |                                                               | `/var/run/postgresql/#{version}-main.pid` | no
-`password`          | String, nil       | Pass in a password, or have the cookbook generate one for you | 'generate'                                | no
+`password`          | String, nil       | Pass in a password, or have the cookbook generate one for you | <random string>                                | no
 
 #### Examples
 


### PR DESCRIPTION
Before it looked like it might be the hardcoded string "generate".

WDYT?