### PR TITLE
Fix control and description for initdb_locale and ident map

### DIFF
--- a/test/integration/ident/controls/ident_map.rb
+++ b/test/integration/ident/controls/ident_map.rb
@@ -1,8 +1,6 @@
-control 'postgresl-ident-map' do
+control 'postgresql-ident-map' do
   impact 1.0
-  desc '
-    This test ensures postgres configures ident access correctly
-  '
+  desc 'This test ensures postgres configures ident access correctly'
 
   describe command("sudo -u shef bash -c \"psql -U sous_chef -d postgres -c 'SELECT 1;'\"") do
     its('exit_status') { should eq 0 }

--- a/test/integration/initdb_locale/controls/default_spec.rb
+++ b/test/integration/initdb_locale/controls/default_spec.rb
@@ -1,6 +1,6 @@
-control 'shef and postgres roles should exist' do
+control 'postgresql-initdb-locale' do
   impact 1.0
-  desc "The check database's locale setting for collation"
+  desc 'This test ensures the locales are correcly set'
 
   postgres_access = postgres_session('postgres', '12345', '127.0.0.1')
 


### PR DESCRIPTION
I think this was a simple copy and paste error and the other just a typo.