### PR TITLE
Fix extension installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Fix installation of extensions.
+
 ## v7.1.3 (15-01-2019)
 
 - Added support for dash in database role name.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -71,7 +71,7 @@ module PostgresqlCookbook
       if new_resource.version
         version_result.stdout == new_resource.version
       else
-        !version_result.stdout.nil?
+        !version_result.stdout.chomp.empty?
       end
     end
 

--- a/test/cookbooks/test/recipes/extension.rb
+++ b/test/cookbooks/test/recipes/extension.rb
@@ -1,6 +1,7 @@
 postgresql_repository 'install'
 
 postgresql_server_install 'package' do
+  password '12345'
   action [:install, :create]
   initdb_locale 'en_US.utf8'
 end

--- a/test/cookbooks/test/recipes/extension.rb
+++ b/test/cookbooks/test/recipes/extension.rb
@@ -4,13 +4,18 @@ postgresql_server_install 'package' do
   password '12345'
   action [:install, :create]
   initdb_locale 'en_US.utf8'
+  version '9.6'
 end
 
 postgresql_database 'test_1' do
   locale 'en_US.utf8'
 end
 
-package 'postgresql-contrib'
+if node['platform_family'] == 'rhel'
+  package 'postgresql96-contrib'
+else
+  package 'postgresql-contrib'
+end
 
 postgresql_extension 'adminpack' do
   database 'test_1'

--- a/test/integration/extension/controls/extension_spec.rb
+++ b/test/integration/extension/controls/extension_spec.rb
@@ -1,0 +1,10 @@
+control 'postgresql-extension' do
+  impact 1.0
+  desc 'Check if the "adminpack" extension was installed successfully'
+
+  postgres_access = postgres_session('postgres', '12345', '127.0.0.1')
+
+  describe postgres_access.query('\dx;', ['test_1']) do
+    its('output') { should include 'adminpack' }
+  end
+end

--- a/test/integration/extension/inspec.yml
+++ b/test/integration/extension/inspec.yml
@@ -1,0 +1,9 @@
+name: extension
+title: PostgreSQL extension tests
+maintainer: Sous Chefs
+copyright_email: help@sous-chefs.org
+license: Apache
+summary: Check that extensions are installed
+version: 0.0.1
+supports:
+  - os-family: unix


### PR DESCRIPTION
### Description

This adds a failing test for https://github.com/sous-chefs/postgresql/pull/577 and I'll add the fix as well once I can get this test to _properly_ fail. Currently it fails, but because it seems that `its('output')` only checks the first line or the second command `\dx;` is never executed. I couldn't find something similar to `before {}` in InSpec to execute `\c test_1;` separately.

I sadly know too little about InSpec to figure out where exactly I'm going wrong here, any help is greatly appreciated!

Current output:
```console
$ kitchen verify extension-ubuntu-1604
...
-----> Verifying <extension-ubuntu-1604>...
       Loaded extension

Profile: PostgreSQL extension tests (extension)
Version: 0.0.1
Target:  ssh://vagrant@127.0.0.1:2222

  ×  postgresql-extension: PostgreSQL query: \c test_1; \dx;
     ×  PostgreSQL query: \c test_1; \dx; output should include "adminpack"
     expected "You are now connected to database \"test_1\" as user \"postgres\"." to include "adminpack"
```

### Issues Resolved

https://github.com/sous-chefs/postgresql/pull/577

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable