### PR TITLE
Server conf: Specify version on conf_dir

### DIFF
--- a/resources/access.rb
+++ b/resources/access.rb
@@ -24,11 +24,12 @@ property :cookbook,      String,                 default: 'postgresql'
 property :source,        String,                 default: 'pg_hba.conf.erb'
 property :access_addr,   String
 property :comment,       String
+property :version,       String,                 default: lazy { default_postgresql_version }
 
 action :grant do
   config_resource = new_resource
   with_run_context :root do # ~FC037
-    edit_resource(:template, "#{conf_dir}/pg_hba.conf") do |new_resource|
+    edit_resource(:template, "#{conf_dir(version)}/pg_hba.conf") do |new_resource|
       source new_resource.source
       cookbook new_resource.cookbook
       owner 'postgres'

--- a/resources/server_conf.rb
+++ b/resources/server_conf.rb
@@ -29,7 +29,7 @@ property :additional_config,    Hash,   default: {}
 property :cookbook,             String, default: 'postgresql'
 
 action :modify do
-  template "#{conf_dir}/postgresql.conf" do
+  template "#{conf_dir(version)}/postgresql.conf" do
     cookbook new_resource.cookbook
     source 'postgresql.conf.erb'
     owner 'postgres'


### PR DESCRIPTION
### Description

Fixes a `conf_dir(version)` that was missed in a previous refactor

### Issues Resolved

Allows `postgresql_server_install` to use the correct data directory

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable