### PR TITLE
Sudo is installed already on these dokken images

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -25,7 +25,6 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo
 
 - name: debian-9
   driver:
@@ -33,7 +32,6 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo
 
 - name: centos-6
   driver:
@@ -56,7 +54,6 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo
 
 - name: ubuntu-18.04
   driver:
@@ -64,4 +61,3 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo


### PR DESCRIPTION
### Description

After doing a little digging into using dokken at work I noticed this dokken config is doing a little extra. Granted the commands will be a no-op, they are not needed since [they](https://github.com/someara/dokken-images/blob/0f3064a5fc81af5dc014e6a64dc85bef5be5f27e/ubuntu-18.04/Dockerfile#L28) [are](https://github.com/someara/dokken-images/blob/0f3064a5fc81af5dc014e6a64dc85bef5be5f27e/debian-8/Dockerfile#L26) [installed already](https://github.com/someara/dokken-images/blob/0f3064a5fc81af5dc014e6a64dc85bef5be5f27e/ubuntu-16.04/Dockerfile#L29)

### Issues Resolved

None

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable