### PR TITLE
Ability to override data_dir and conf_dir paths

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,2 @@
+default['postgresql']['data_dir'] = nil
+default['postgresql']['conf_dir'] = nil

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -137,7 +137,8 @@ module PostgresqlCookbook
       psql_command_string(new_resource, sql)
     end
 
-    def data_dir(version = node.run_state['postgresql']['version'])
+    def data_dir(override_path = node.read['postgresql']['data_dir'], version = node.run_state['postgresql']['version'])
+      return override_path if override_path
       case node['platform_family']
       when 'rhel', 'fedora'
         "/var/lib/pgsql/#{version}/data"
@@ -152,7 +153,8 @@ module PostgresqlCookbook
       end
     end
 
-    def conf_dir(version = node.run_state['postgresql']['version'])
+    def conf_dir(override_path = node.read['postgresql']['conf_dir'], version = node.run_state['postgresql']['version'])
+      return override_path if override_path
       case node['platform_family']
       when 'rhel', 'fedora'
         "/var/lib/pgsql/#{version}/data"


### PR DESCRIPTION
### Description

Adds the ability to override the data_dir and conf_dir folders.

### Issues Resolved

https://github.com/sous-chefs/postgresql/issues/604

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable