### PR TITLE
Create a createcluster.conf.erb file when ubuntu / debian

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,12 @@ lint_and_unit: &lint_and_unit
   - danger
   - lint-yaml
   - lint-markdown
-
 version: 2.1
 orbs:
   kitchen: sous-chefs/kitchen@2
-
 workflows:
   kitchen:
     jobs:
-      # Lint and Unit Test
       - kitchen/yamllint:
           name: lint-yaml
       - kitchen/mdlint:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -213,6 +213,7 @@ module PostgresqlCookbook
               "/usr/pgsql-#{new_resource.version}/bin/initdb"
             end
       cmd << " --locale '#{new_resource.initdb_locale}'" if new_resource.initdb_locale
+      cmd << " -E '#{new_resource.initdb_encoding}'" if new_resource.initdb_encoding
       cmd << " -D '#{data_dir(new_resource.version)}'"
     end
 

--- a/templates/createcluster.conf.erb
+++ b/templates/createcluster.conf.erb
@@ -1,0 +1,41 @@
+# Default values for pg_createcluster(8)
+# Occurrences of '%v' are replaced by the major version number,
+# and '%c' by the cluster name. Use '%%' for a literal '%'.
+
+# Create a "main" cluster when a new postgresql-x.y server package is installed
+#create_main_cluster = true
+
+# Default start.conf value, must be one of "auto", "manual", and "disabled".
+# See pg_createcluster(8) for more documentation.
+#start_conf = 'auto'
+
+# Default data directory.
+data_directory = '<%= @data_dir %>'
+
+# Default directory for transaction logs
+# Unset by default, i.e. transaction logs remain in the data directory.
+#waldir = '/var/lib/postgresql/wal/%v/%c/pg_wal'
+
+# Options to pass to initdb.
+initdb_options = '<%= @initdb_options %>'
+
+# The following options are copied into the new cluster's postgresql.conf:
+
+# Enable SSL by default (using the "snakeoil" certificates installed by the
+# ssl-cert package, unless configured otherwise here)
+ssl = on
+
+# Show cluster name in process title
+cluster_name = '%v/%c'
+
+# Put stats_temp_directory on tmpfs
+stats_temp_directory = '/var/run/postgresql/%v-%c.pg_stat_tmp'
+
+# Add prefix to log lines
+log_line_prefix = '%%m [%%p] %%q%%u@%%d '
+
+# Add "include_dir" in postgresql.conf
+add_include_dir = 'conf.d'
+
+# Directory for additional createcluster config
+include_dir '/etc/postgresql-common/createcluster.d'


### PR DESCRIPTION
# Description

Ubuntu provides `postgresql-common` to manage multiple pg clusters on one host. This comes with a createcluster.conf file that determines how a new cluster is created. By default when installing the postgres server package a new cluster is created using the createcluster.conf file

## Issues Resolved

#596 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
