### PR TITLE
Run latest cookstyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,3 +151,4 @@ this will be the last release of the 6.0 series before all recipes are removed f
 - Remove logic in the apt_pgdg_postgresql recipe that made Chef fail when new distro releases came out
 - Avoid node.set deprecation warnings
 - Avoid managed_home deprecation warnings in server_redhat recipe
+- Run latest cookstyle

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,6 @@ maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures postgresql for clients or servers'
-long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '7.1.4'
 source_url        'https://github.com/sous-chefs/postgresql'
 issues_url        'https://github.com/sous-chefs/postgresql/issues'

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -2,7 +2,7 @@
 name 'test'
 maintainer 'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Installs/Configures test'
 version '0.1.0'
 

--- a/test/cookbooks/test/recipes/extension.rb
+++ b/test/cookbooks/test/recipes/extension.rb
@@ -11,7 +11,7 @@ postgresql_database 'test_1' do
   locale 'en_US.utf8'
 end
 
-if node['platform_family'] == 'rhel'
+if platform_family?('rhel')
   package 'postgresql96-contrib'
 else
   package 'postgresql-contrib'


### PR DESCRIPTION
# Description

Run latest cookstyle

## Issues Resolved
```
→ cookstyle -a
Inspecting 29 files
.R.........R....R.....R......

Offenses:

metadata.rb:7:1: R: [Corrected] ChefDeprecations/LongDescriptionMetadata: The long_description metadata.rb method is not used and is unnecessary in cookbooks
long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/cookbooks/test/recipes/extension.rb:14:4: R: [Corrected] ChefStyle/UsePlatformHelpers: Use platform? and platform_family? helpers for checking node platform
if node['platform_family'] == 'rhel'
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/cookbooks/test/metadata.rb:5:9: R: [Corrected] ChefCorrectness/InvalidLicenseString: Cookbook metadata.rb does not use a SPDX compliant license string or "all rights reserved". See https://spdx.org/licenses/ for a complete list of license identifiers.
license 'Apache 2.0'
        ^^^^^^^^^^^^
resources/access.rb:19:1: R: ChefCorrectness/PropertyWithRequiredAndDefault: Resource property should not be both required and have a default value. This will fail on Chef Infra Client 13+
property :access_type,   String, required: true, default: 'local'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/access.rb:20:1: R: ChefCorrectness/PropertyWithRequiredAndDefault: Resource property should not be both required and have a default value. This will fail on Chef Infra Client 13+
property :access_db,     String, required: true, default: 'all'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/access.rb:21:1: R: ChefCorrectness/PropertyWithRequiredAndDefault: Resource property should not be both required and have a default value. This will fail on Chef Infra Client 13+
property :access_user,   String, required: true, default: 'postgres'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
resources/access.rb:22:1: R: ChefCorrectness/PropertyWithRequiredAndDefault: Resource property should not be both required and have a default value. This will fail on Chef Infra Client 13+
property :access_method, String, required: true, default: 'ident'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

29 files inspected, 7 offenses detected, 3 offenses corrected
```
## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
