### PR TITLE
Use true/false in properties and remove nil defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
-- Use TrueClass and FalseClass in resource properties
+- Remove unnecessary nil default in resource properties
 - Migrate to actions for testing
 
 ## v7.1.5 (2019-11-18)

--- a/resources/client_install.rb
+++ b/resources/client_install.rb
@@ -17,7 +17,7 @@
 #
 
 property :version,    String, default: '9.6'
-property :setup_repo, [TrueClass, FalseClass], default: true
+property :setup_repo, [true, false], default: true
 
 action :install do
   postgresql_repository 'Add downloads.postgresql.org repository' do

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -23,7 +23,7 @@ property :owner,    String
 # Connection prefernces
 property :user,     String, default: 'postgres'
 property :database, String, name_property: true
-property :host,     [String, nil], default: nil
+property :host,     String
 property :port,     Integer, default: 5432
 
 action :create do

--- a/resources/ident.rb
+++ b/resources/ident.rb
@@ -21,7 +21,7 @@ property :source,      String, default: 'pg_ident.conf.erb'
 property :cookbook,    String, default: 'postgresql'
 property :system_user, String, required: true
 property :pg_user,     String, required: true
-property :comment,     [String, nil], default: nil
+property :comment,     String
 
 action :create do
   ident_resource = new_resource

--- a/resources/ident.rb
+++ b/resources/ident.rb
@@ -25,7 +25,7 @@ property :comment,     String
 
 action :create do
   ident_resource = new_resource
-  with_run_context :root do # ~FC037
+  with_run_context :root do
     edit_resource(:template, "#{conf_dir}/pg_ident.conf") do |new_resource|
       source new_resource.source
       cookbook new_resource.cookbook

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -17,10 +17,10 @@
 #
 
 property :version,                            String, default: '9.6'
-property :enable_pgdg,                        [TrueClass, FalseClass], default: true
-property :enable_pgdg_source,                 [TrueClass, FalseClass], default: false
-property :enable_pgdg_updates_testing,        [TrueClass, FalseClass], default: false
-property :enable_pgdg_source_updates_testing, [TrueClass, FalseClass], default: false
+property :enable_pgdg,                        [true, false], default: true
+property :enable_pgdg_source,                 [true, false], default: false
+property :enable_pgdg_updates_testing,        [true, false], default: false
+property :enable_pgdg_source_updates_testing, [true, false], default: false
 property :yum_gpg_key_uri, String, default: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG'
 property :apt_gpg_key_uri, String, default: 'https://download.postgresql.org/pub/repos/apt/ACCC4CF8.asc'
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -19,7 +19,7 @@
 include PostgresqlCookbook::Helpers
 
 property :version,           String, default: '9.6'
-property :setup_repo,        [TrueClass, FalseClass], default: true
+property :setup_repo,        [true, false], default: true
 property :hba_file,          String, default: lazy { "#{conf_dir}/main/pg_hba.conf" }
 property :ident_file,        String, default: lazy { "#{conf_dir}/main/pg_ident.conf" }
 property :external_pid_file, String, default: lazy { "/var/run/postgresql/#{version}-main.pid" }

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -16,12 +16,12 @@
 #
 
 property :create_user,        String, name_property: true
-property :superuser,          [TrueClass, FalseClass], default: false
-property :createdb,           [TrueClass, FalseClass], default: false
-property :createrole,         [TrueClass, FalseClass], default: false
-property :inherit,            [TrueClass, FalseClass], default: true
-property :replication,        [TrueClass, FalseClass], default: false
-property :login,              [TrueClass, FalseClass], default: true
+property :superuser,          [true, false], default: false
+property :createdb,           [true, false], default: false
+property :createrole,         [true, false], default: false
+property :inherit,            [true, false], default: true
+property :replication,        [true, false], default: false
+property :login,              [true, false], default: true
 property :password,           String
 property :encrypted_password, String
 property :valid_until,        String


### PR DESCRIPTION
String values always default to nil. Remove these nil defaults.

Signed-off-by: Tim Smith <tsmith@chef.io>