### PR TITLE
Passes attr to update_user_with_attributes_sql

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -128,7 +128,7 @@ module PostgresqlCookbook
     end
 
     def update_user_with_attributes_sql(new_resource, attr, value)
-      sql = %(ALTER ROLE '#{new_resource.create_user}' SET #{attr} = #{value})
+      sql = %(ALTER ROLE #{new_resource.create_user} SET #{attr} = #{value})
       psql_command_string(new_resource, sql)
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -127,7 +127,7 @@ module PostgresqlCookbook
       psql_command_string(new_resource, sql)
     end
 
-    def update_user_with_attributes_sql(new_resource, value)
+    def update_user_with_attributes_sql(new_resource, attr, value)
       sql = %(ALTER ROLE '#{new_resource.create_user}' SET #{attr} = #{value})
       psql_command_string(new_resource, sql)
     end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -65,7 +65,7 @@ action :update do
 
       execute "Update postgresql user #{new_resource.create_user} to set #{attr}" do
         user 'postgres'
-        command update_user_with_attributes_sql(new_resource, v)
+        command update_user_with_attributes_sql(new_resource, attr, v)
         environment(psql_environment)
         sensitive true
         not_if { follower? }

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -20,6 +20,12 @@ postgresql_user 'sous_chef' do
   sensitive false
 end
 
+postgresql_user 'sous_chef' do
+  attributes({ statement_timeout: '8min' })
+  sensitive false
+  action :update
+end
+
 postgresql_access 'a sous_chef local superuser' do
   access_type 'host'
   access_db 'all'

--- a/test/integration/access/controls/base_access.rb
+++ b/test/integration/access/controls/base_access.rb
@@ -45,6 +45,17 @@ control 'sous_chef role should exist' do
   end
 end
 
+control 'sous_chef has statement_timeout set to 8mins' do
+  impact 1.0
+  desc 'Ensures attributes are applied'
+
+  postgres_access = postgres_session('sous_chef', '67890')
+
+  describe postgres_access.query('SHOW statement_timeout;', ['postgres']) do
+    its('output') { should cmp /8min/ }
+  end
+end
+
 control 'name-with-dash role should exist' do
   impact 1.0
   desc 'The name-with-dash database user role should exist'


### PR DESCRIPTION
# Description

Passes `attr` to `update_user_with_attributes_sql` to make updates on `postgresql_user` work with attribute hashes.

Also removes quotes from rolname, as that's a syntax error in postgresql.

## Issues Resolved

Fixes https://github.com/sous-chefs/postgresql/issues/653

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] ~~New functionality has been documented in the README if applicable~~.
