### PR TITLE
Update to testing modern OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,13 @@ jobs:
     strategy:
       matrix:
         os:
+          - 'amazonlinux-2'
           - 'debian-9'
-          - 'centos-6'
+          - 'debian-10'
           - 'centos-7'
-          - 'ubuntu-1604'
+          - 'centos-8'
           - 'ubuntu-1804'
+          - 'ubuntu-2004'
         suite:
           - 'extension'
           - 'ident'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file is used to list changes made in the last 3 major versions of the postgresql cookbook.
 
+## Unreleased
+
+- Removed testing of ubuntu 16.04
+- Removed testing of centos 6
+- Added testing of amazonlinux 2
+- Added testing of debian 10
+- Added testing of centos 8
+- Added testing of ubuntu 20.04
+- added `attr` to `update_user_with_attributes_sql` to make updates on `postgresql_user` work with attribute hashes.
+- fixed rolename, removed quotes due to syntax error
+
 ## v7.1.9 (2020-05-14)
 
 - resolved cookstyle error: resources/access.rb:30:28 convention: `Layout/TrailingWhitespace`

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -21,22 +21,24 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
-  - name: centos-6
+  - name: debian-10
     driver:
-      image: dokken/centos-6
-      pid_one_command: /sbin/init
+      image: dokken/debian-10
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
 
   - name: centos-7
     driver:
       image: dokken/centos-7
+      platform: rhel
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-16.04
+  - name: centos-8
     driver:
-      image: dokken/ubuntu-16.04
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+      image: dokken/centos-8
+      platform: rhel
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: ubuntu-18.04
     driver:
@@ -44,3 +46,15 @@ platforms:
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
+
+  - name: ubuntu-20.04
+    driver:
+      image: dokken/ubuntu-16.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
+  - name: amazonlinux-2
+    driver:
+      image: dokken/amazonlinux-2
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,14 +15,13 @@ verifier:
   name: inspec
 
 platforms:
-  - name: amazonlinux-2
-    driver_config:
-      box: ywatase/amzn2
-  - name: centos-6
-  - name: centos-7
   - name: debian-9
-  - name: ubuntu-16.04
+  - name: debian-10
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
+  - name: centos-7
+  - name: centos-8
+  - name: amazonlinux-2
 
 suites:
   - name: repo


### PR DESCRIPTION
# Description

Update to testing modern OS

- Removed testing of ubuntu 16.04
- Removed testing of centos 6
- Added testing of amazonlinux 2
- Added testing of debian 10
- Added testing of centos 8
- Added testing of ubuntu 20.04

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
