### PR TITLE
Removes quotes around user in DROP ROLE IF EXISTS

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -139,7 +139,7 @@ module PostgresqlCookbook
     end
 
     def drop_user_sql(new_resource)
-      sql = %(DROP ROLE IF EXISTS '#{new_resource.create_user}')
+      sql = %(DROP ROLE IF EXISTS #{new_resource.create_user})
       psql_command_string(new_resource, sql)
     end
 

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -40,6 +40,11 @@ postgresql_user 'name-with-dash' do
   password '1234'
 end
 
+postgresql_user 'dropable-user' do
+  password '1234'
+  action [:create, :drop]
+end
+
 service 'postgresql' do
   extend PostgresqlCookbook::Helpers
   service_name lazy { platform_service_name }


### PR DESCRIPTION
Fixes https://github.com/sous-chefs/postgresql/issues/629

# Description

Fixes sql syntax by removing quotes around username in DROP ROLE IF EXISTS

## Issues Resolved

Resolves https://github.com/sous-chefs/postgresql/issues/629

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] ~~New functionality has been documented in the README if applicable.~~
