### PR TITLE
[GH-670] Use system default locale when creating databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Use system default locale when creating databases
 - resolved cookstyle error: spec/libraries/helpers_spec.rb:2:18 convention: `Style/RedundantFileExtensionInRequire`
 
 ## v8.0.0 (2020-08-26)

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ Name       | Types   | Description                                              
 `template` | String  | Template used to create the new database                            | 'template1'         | no
 `host`     | String  | Define the host server where the database creation will be executed | Not set (localhost) | no
 `port`     | Integer | Define the port of PostgreSQL server                                | 5432                | no
-`encoding` | String  | Define database encoding                                            | 'UTF-8'             | no
-`locale`   | String  | Define database locale                                              | 'en_US.UTF-8'       | no
+`encoding` | String  | Define database encoding                                            | Not set             | no
+`locale`   | String  | Define database locale                                              | Not set             | no
 `owner`    | String  | Define the owner of the database                                    | Not set             | no
 
 #### Examples

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -17,8 +17,8 @@
 provides :postgresql_database
 
 property :template, String, default: 'template1'
-property :encoding, String, default: 'UTF-8'
-property :locale,   String, default: 'en_US.UTF-8'
+property :encoding, String
+property :locale,   String
 property :owner,    String
 
 # Connection prefernces


### PR DESCRIPTION
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>

# Description

When creating a database with the `postgresql_database` the default locale is set to `en_US.UTF-8`. This fails, if the default system locale differs. This PR drops the default locale of the database resource. Thus system defaults are applied in accordance with the `initdb` settings of the `postgresql_server_install` resource.

## Issues Resolved

 * #670 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] ~~New functionality includes testing.~~ (not applicable, no new functionality)
- [ ] ~~New functionality has been documented in the README if applicable.~~ (not applicable, no new functionality)
