### PR TITLE
Fix quotes around user in DROP ROLE IF EXISTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in the last 3 major versions of the postgresql cookbook.
 
+## Unreleased
+
+- Fix quoting of DROP ROLE query
+
 ## v8.0.1 (2020-11-12)
 
 - Use system default locale when creating databases

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -139,7 +139,7 @@ module PostgresqlCookbook
     end
 
     def drop_user_sql(new_resource)
-      sql = %(DROP ROLE IF EXISTS '#{new_resource.create_user}')
+      sql = %(DROP ROLE IF EXISTS #{new_resource.create_user})
       psql_command_string(new_resource, sql)
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -139,7 +139,7 @@ module PostgresqlCookbook
     end
 
     def drop_user_sql(new_resource)
-      sql = %(DROP ROLE IF EXISTS #{new_resource.create_user})
+      sql = %(DROP ROLE IF EXISTS \\"#{new_resource.create_user}\\")
       psql_command_string(new_resource, sql)
     end
 

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -43,6 +43,20 @@ end
 postgresql_user 'dropable-user' do
   password '1234'
   action [:create, :drop]
+
+  # Prevent the test suite from creating and dropping the user again. This
+  # would raise an error during the second run, as it seems the resource didn't
+  # converge properly.
+  notifies :run, 'ruby_block[user_dropped]'
+  not_if { node.attribute? 'user_dropped' }
+end
+
+ruby_block 'user_dropped' do
+  block do
+    node.normal['user_dropped'] = true
+    node.save
+  end
+  action :nothing
 end
 
 service 'postgresql' do

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -40,6 +40,11 @@ postgresql_user 'name-with-dash' do
   password '1234'
 end
 
+postgresql_user 'dropable-user' do
+  password '1234'
+  action [:create, :drop]
+end
+
 service 'postgresql' do
   extend PostgresqlCookbook::Helpers
   service_name lazy { platform_service_name }


### PR DESCRIPTION
# Description

Fixes SQL syntax by removing quotes around username in DROP ROLE IF EXISTS.

I am not allowed to change the original PR. So I hope it's okay to open a new one.

## Issues Resolved

- Resolves #629
- Resolves #661

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
