### PR TITLE
Add sensitive option to password properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Fix potential password exposure in logs
+
 ## 8.0.2 - *2020-11-20*
 
 - Fix quoting of DROP ROLE query

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -23,7 +23,7 @@ property :setup_repo,        [true, false], default: true
 property :hba_file,          String, default: lazy { "#{conf_dir}/main/pg_hba.conf" }
 property :ident_file,        String, default: lazy { "#{conf_dir}/main/pg_ident.conf" }
 property :external_pid_file, String, default: lazy { "/var/run/postgresql/#{version}-main.pid" }
-property :password,          [String, nil], default: 'generate' # Set to nil if we do not want to set a password
+property :password,          [String, nil], default: 'generate', sensitive: true # Set to nil if we do not want to set a password
 property :port,              Integer, default: 5432
 property :initdb_locale,     String
 property :initdb_encoding,   String

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -23,7 +23,7 @@ property :createrole,         [true, false], default: false
 property :inherit,            [true, false], default: true
 property :replication,        [true, false], default: false
 property :login,              [true, false], default: true
-property :password,           String
+property :password,           String, sensitive: true
 property :encrypted_password, String
 property :valid_until,        String
 property :attributes,         Hash, default: {}


### PR DESCRIPTION
# Description

This updates password properties with the `sensitive` option. This should prevent passwords from being leaked to the logs.

Reference: https://github.com/chef/chef/blob/6ecacec32423b116e64fdcc11be0e8e18ce94706/lib/chef/provider.rb#L324-L329

## Issues Resolved

N/A

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
