### PR TITLE
quotes roles when updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Fix attribute updates for users with dashes
+
 ## 8.1.0 - *2020-12-09*
 
 - Fix potential password exposure in logs

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -134,7 +134,7 @@ module PostgresqlCookbook
     end
 
     def update_user_with_attributes_sql(new_resource, attr, value)
-      sql = %(ALTER ROLE #{new_resource.create_user} SET #{attr} = #{value})
+      sql = %(ALTER ROLE \\"#{new_resource.create_user}\\" SET #{attr} = #{value})
       psql_command_string(new_resource, sql)
     end
 

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -40,6 +40,12 @@ postgresql_user 'name-with-dash' do
   password '1234'
 end
 
+postgresql_user 'name-with-dash' do
+  attributes({ statement_timeout: '8min' })
+  sensitive false
+  action :update
+end
+
 postgresql_user 'dropable-user' do
   password '1234'
   action [:create, :drop]

--- a/test/integration/access/controls/base_access.rb
+++ b/test/integration/access/controls/base_access.rb
@@ -66,3 +66,14 @@ control 'name-with-dash role should exist' do
     its('output') { should cmp /name-with-dash/ }
   end
 end
+
+control 'name-with-dash role has statement_timeout set to 8mins' do
+  impact 1.0
+  desc 'Ensures attributes are applied on users with dashes'
+
+  postgres_access = postgres_session('postgres', '12345', '127.0.0.1')
+
+  describe postgres_access.query("SELECT rolconfig FROM pg_roles where rolname = 'name-with-dash';") do
+    its('output') { should cmp /statement_timeout=8min/ }
+  end
+end


### PR DESCRIPTION
Fixes incompatibility with users with dashes in their names.

# Description

Without this change, it breaks on updating `postgresql_user` resources where roles have dashes in their names.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
