### PR TITLE
[GH-676] Disables psqlrc for helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+## Unreleased
+
+- Makes psqlrc optional when invoking `psql_command_string`
+
 ## 8.1.1 - *2021-01-12*
 
 - Fix attribute updates for users with dashes

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -28,6 +28,7 @@ module PostgresqlCookbook
       cmd << " --host #{new_resource.host}" if new_resource.host
       cmd << " --port #{new_resource.port}" if new_resource.port
       cmd << ' --tuples-only'               if value_only
+      cmd << ' --no-psqlrc'                 unless new_resource.psqlrc
       cmd << " | grep #{grep_for}"          if grep_for
       cmd
     end

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -26,6 +26,7 @@ property :user,     String, default: 'postgres'
 property :database, String, name_property: true
 property :host,     String
 property :port,     Integer, default: 5432
+property :psqlrc,   [true, false], default: true
 
 action :create do
   createdb = 'createdb'

--- a/resources/extension.rb
+++ b/resources/extension.rb
@@ -25,6 +25,7 @@ property :user,     String, default: 'postgres'
 property :database, String, required: true
 property :host,     [String, nil]
 property :port,     Integer, default: 5432
+property :psqlrc,   [true, false], default: true
 
 action :create do
   bash "CREATE EXTENSION #{new_resource.name}" do

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -32,6 +32,7 @@ property :initdb_encoding,   String
 property :user,     String, default: 'postgres'
 property :database, String
 property :host,     [String, nil]
+property :psqlrc,   [true, false], default: true
 
 action :install do
   node.run_state['postgresql'] ||= {}

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -33,6 +33,7 @@ property :user,     String, default: 'postgres'
 property :database, String
 property :host,     String
 property :port,     Integer, default: 5432
+property :psqlrc,   [true, false], default: true
 
 action :create do
   Chef::Log.warn('You cannot use "attributes" property with create action.') unless new_resource.attributes.empty?

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe PostgresqlCookbook::Helpers do
         @new_resource = double(database: 'db_foo',
                               user: 'postgres',
                               host: 'localhost',
-                              port: '5432'
+                              port: '5432',
+                              psqlrc: true
                               )
         @query = 'THIS IS A COMMAND STRING'
       end
@@ -102,13 +103,15 @@ RSpec.describe PostgresqlCookbook::Helpers do
           database: 'test_1234',
           user: 'postgres',
           port: '5432',
-          host: nil
+          host: nil,
+          psqlrd: true
         )
         res = double(
           user: new_resource.user,
           port: new_resource.port,
           database: nil,
-          host: nil
+          host: nil,
+          psqlrc: true
         )
 
         db_query = 'SELECT datname from pg_database WHERE datname=\'test_1234\''
@@ -124,7 +127,8 @@ RSpec.describe PostgresqlCookbook::Helpers do
           database: nil,
           user: 'postgres',
           port: '5432',
-          host: '127.0.0.1'
+          host: '127.0.0.1',
+          psqlrc: true
         )
         db_query = 'SELECT datname from pg_database WHERE datname=\'test_1234\''
         result = %(/usr/bin/psql -c "SELECT datname from pg_database WHERE datname='test_1234'" -U postgres --host 127.0.0.1 --port 5432)
@@ -137,10 +141,24 @@ RSpec.describe PostgresqlCookbook::Helpers do
           database: nil,
           user: 'postgres',
           port: '5432',
-          host: nil
+          host: nil,
+          psqlrc: true
         )
         query = 'SELECT datname from pg_database WHERE datname=\'postgres\''
         result = %(/usr/bin/psql -c "SELECT datname from pg_database WHERE datname='postgres'" -U postgres --port 5432)
+
+        expect(subject.psql_command_string(new_resource, query)).to eq(result)
+      end
+      it 'Allow psqlrc to be ignored' do
+        new_resource = double(
+          database: nil,
+          user: 'postgres',
+          port: '5432',
+          host: '127.0.0.1',
+          psqlrc: false
+        )
+        query = 'SELECT datname from pg_database WHERE datname=\'postgres\''
+        result = %(/usr/bin/psql -c "SELECT datname from pg_database WHERE datname='postgres'" -U postgres --host 127.0.0.1 --port 5432 --no-psqlrc)
 
         expect(subject.psql_command_string(new_resource, query)).to eq(result)
       end
@@ -180,7 +198,8 @@ RSpec.describe PostgresqlCookbook::Helpers do
           initdb_locale: 'UTF-8',
           user: 'postgres',
           database: nil,
-          host: nil
+          host: nil,
+          psqlrc: true
         )
         result = %(/usr/bin/psql -c "ALTER ROLE postgres ENCRYPTED PASSWORD '12345';" -U postgres --port 5432)
 
@@ -196,7 +215,8 @@ RSpec.describe PostgresqlCookbook::Helpers do
           user: 'postgres',
           database: nil,
           host: nil,
-          port: 5432
+          port: 5432,
+          psqlrc: true
         )
         result = %(/usr/bin/psql -c "CREATE EXTENSION IF NOT EXISTS \\\"plpgsql\\\"" -U postgres --port 5432)
 
@@ -211,7 +231,8 @@ RSpec.describe PostgresqlCookbook::Helpers do
             user: 'postgres',
             database: nil,
             host: nil,
-            port: 5432
+            port: 5432,
+            psqlrc: true
           )
           result = %(/usr/bin/psql -c "CREATE EXTENSION IF NOT EXISTS \\\"uuid-ossp\\\"" -U postgres --port 5432)
 


### PR DESCRIPTION
The psqlrc files should not be read by helperscripts.

Entries such as `/timing` will introduce unexpected output, potentially failing
`not_if` functionality when invoking these helpers.

Ref: https://github.com/sous-chefs/postgresql/issues/676

Signed-off-by: Mike Morraye <hello@morraye.be>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
