### PR TITLE
Fix idempotency when installing multiple client versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           - 'client-install-12'
           - 'client-install-95'
           - 'client-install-96'
+          - 'client-multi-install'
           - 'extension-10'
           - 'extension-11'
           - 'extension-12'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Fix idempotency when installing multiple client versions
+
 ## 8.2.1 - *2021-02-08*
 
 - Fix changelog formatting

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -335,6 +335,12 @@ suites:
         pg_ver: '9.5'
     run_list:
       - recipe[test::client_install]
+  - name: client_multi_install
+    verifier:
+      inspec_tests:
+        - path: test/integration/client_multi_install/
+    run_list:
+      - recipe[test::multi_client]
   - name: extension_95
     attributes:
       test:

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -31,7 +31,7 @@ action :add do
 
   when 'rhel', 'fedora', 'amazon'
 
-    remote_file "/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}" do
+    remote_file '/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG' do
       source new_resource.yum_gpg_key_uri
     end
 
@@ -46,7 +46,7 @@ action :add do
       baseurl     yum_repo_url('https://download.postgresql.org/pub/repos/yum')
       enabled     new_resource.enable_pgdg
       gpgcheck    true
-      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}"
+      gpgkey      'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
     end
 
     yum_repository 'Postgresql - common' do
@@ -55,7 +55,7 @@ action :add do
       baseurl yum_common_repo_url
       enabled new_resource.enable_pgdg_common
       gpgcheck true
-      gpgkey "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}"
+      gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
     end
 
     yum_repository "PostgreSQL #{new_resource.version} - source " do
@@ -64,7 +64,7 @@ action :add do
       baseurl     yum_repo_url('https://download.postgresql.org/pub/repos/yum/srpms')
       enabled     new_resource.enable_pgdg_source
       gpgcheck    true
-      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}"
+      gpgkey      'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
     end
 
     yum_repository "PostgreSQL #{new_resource.version} - updates testing" do
@@ -73,7 +73,7 @@ action :add do
       baseurl     yum_repo_url('https://download.postgresql.org/pub/repos/yum/testing')
       enabled     new_resource.enable_pgdg_updates_testing
       gpgcheck    true
-      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}"
+      gpgkey      'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
     end
 
     yum_repository "PostgreSQL #{new_resource.version} - source - updates testing" do
@@ -82,7 +82,7 @@ action :add do
       baseurl     yum_repo_url('https://download.postgresql.org/pub/repos/yum/srpms/testing')
       enabled     new_resource.enable_pgdg_source_updates_testing
       gpgcheck    true
-      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}"
+      gpgkey      'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
     end
 
   when 'debian'
@@ -90,7 +90,7 @@ action :add do
 
     package 'apt-transport-https'
 
-    apt_repository 'postgresql_org_repository' do
+    apt_repository "postgresql_org_repository_#{new_resource.version.to_s}" do
       uri          'https://download.postgresql.org/pub/repos/apt/'
       components   ['main', new_resource.version.to_s]
       distribution "#{node['lsb']['codename']}-pgdg"

--- a/test/cookbooks/test/recipes/multi_client.rb
+++ b/test/cookbooks/test/recipes/multi_client.rb
@@ -1,0 +1,7 @@
+postgresql_client_install '11' do
+  version '11'
+end
+
+postgresql_client_install '12' do
+  version '12'
+end

--- a/test/integration/client_multi_install/controls/client_spec.rb
+++ b/test/integration/client_multi_install/controls/client_spec.rb
@@ -1,0 +1,24 @@
+pg_path =
+  case os.family
+  when 'debian'
+    '/usr/lib/postgresql/'
+  when 'redhat', 'fedora'
+    '/usr/pgsql-'
+  end
+
+control 'postgresql-client-multi-install' do
+  describe command('/usr/bin/psql -V') do
+    its('stdout') { should match(/psql \(PostgreSQL\) 12.\d/) }
+    its('exit_status') { should eq 0 }
+  end
+
+  describe command("#{pg_path}11/bin/psql -V") do
+    its('stdout') { should match(/psql \(PostgreSQL\) 11.\d/) }
+    its('exit_status') { should eq 0 }
+  end
+
+  describe command("#{pg_path}12/bin/psql -V") do
+    its('stdout') { should match(/psql \(PostgreSQL\) 12.\d/) }
+    its('exit_status') { should eq 0 }
+  end
+end

--- a/test/integration/client_multi_install/inspec.yml
+++ b/test/integration/client_multi_install/inspec.yml
@@ -1,0 +1,2 @@
+---
+name: client-multi


### PR DESCRIPTION
This fixes an issue when trying to install multiple versions of postgresql on the same system. This is useful on backup servers where you might be backing up several different versions and it's best to use the correct version when doing that.

On RHEL-based systems, this changes the name of the gpg key to *not* include the PostgreSQL version. Each repo uses the same key so this shouldn't be a problem.

On Debian-based systems, create a different repo based on the version you're using so that it also works on those systems.

Signed-off-by: Lance Albertson <lance@osuosl.org>
