### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- resolved cookstyle error: spec/libraries/helpers_spec.rb:84:31 convention: `Layout/ClosingParenthesisIndentation`
 ## 9.0.2 - *2021-06-01*
 
 ## 9.0.1 - *2021-05-13*

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe PostgresqlCookbook::Helpers do
                               host: 'localhost',
                               port: '5432',
                               psqlrc: true
-                              )
+        )
         @query = 'THIS IS A COMMAND STRING'
       end
 


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.16.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with spec/libraries/helpers_spec.rb

 - 84:31 convention: `Layout/ClosingParenthesisIndentation` - Indent `)` to column 8 (not 30)