### PR TITLE
Allow installing native distribution packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 ## Unreleased
 
 - resolved cookstyle error: resources/role.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- Allow installing distributions native packages
+
 ## 11.0.1 - *2022-12-13*
 
 Standardise files with files in sous-chefs/repo-management

--- a/documentation/postgresql_install.md
+++ b/documentation/postgresql_install.md
@@ -21,7 +21,7 @@
 | ---------------------------------- | ----- | --------------- | ------- | ------------------------------------------------ | -------------- |
 | `sensitive`                        |       | true, false     |         |                                                  |                |
 | `version`                          |       | String, Integer |         | Version to install                               |                |
-| `source`                           |       | String, Symbol  |         | Installation source                              | repo           |
+| `source`                           |       | String, Symbol  |         | Installation source                              | repo, native   |
 | `client_packages`                  |       | String, Array   |         | Client packages to install                       |                |
 | `server_packages`                  |       | String, Array   |         | Server packages to install                       |                |
 | `repo_pgdg`                        |       | true, false     |         | Create pgdg repo                                 |                |

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -193,6 +193,19 @@ suites:
         pg_ver: "13"
     run_list:
       - recipe[test::client_install]
+  - name: client_install_native_13
+    attributes:
+      test:
+        pg_ver: "13"
+    verifier:
+      inspec_tests:
+        - path: test/integration/client_install_native/
+      inputs:
+        pg_ver: "13"
+    run_list:
+      - recipe[test::client_install_native]
+    includes:
+      - debian-11 # Debian 11 only supports PostgreSQL 13 natively
   - name: extension_13
     attributes:
       test:
@@ -242,6 +255,19 @@ suites:
         pg_ver: "13"
     run_list:
       - recipe[test::server_install]
+  - name: server_install_native_13
+    attributes:
+      test:
+        pg_ver: "13"
+    verifier:
+      inspec_tests:
+        - path: test/integration/server_install_native/
+      inputs:
+        pg_ver: "13"
+    run_list:
+      - recipe[test::server_install_native]
+    includes:
+      - debian-11 # Debian 11 only supports PostgreSQL 13 natively
 
   - name: access_12
     attributes:
@@ -333,6 +359,19 @@ suites:
         pg_ver: "11"
     run_list:
       - recipe[test::client_install]
+  - name: client_install_native_11
+    attributes:
+      test:
+        pg_ver: "11"
+    verifier:
+      inspec_tests:
+        - path: test/integration/client_install_native/
+      inputs:
+        pg_ver: "11"
+    run_list:
+      - recipe[test::client_install_native]
+    includes:
+      - debian-10 # Debian 10 only supports PostgreSQL 11 natively
   - name: extension_11
     attributes:
       test:
@@ -382,3 +421,16 @@ suites:
         pg_ver: "11"
     run_list:
       - recipe[test::server_install]
+  - name: server_install_native_11
+    attributes:
+      test:
+        pg_ver: "11"
+    verifier:
+      inspec_tests:
+        - path: test/integration/server_install_native/
+      inputs:
+        pg_ver: "11"
+    run_list:
+      - recipe[test::server_install_native]
+    includes:
+      - debian-10 # Debian 10 only supports PostgreSQL 11 natively

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -30,7 +30,7 @@ property :version, [String, Integer],
 property :source, [String, Symbol],
           default: :repo,
           coerce: proc { |p| p.to_sym },
-          equal_to: %i(repo),
+          equal_to: %i(repo native),
           description: 'Installation source'
 
 property :client_packages, [String, Array],

--- a/test/cookbooks/test/recipes/client_install_native.rb
+++ b/test/cookbooks/test/recipes/client_install_native.rb
@@ -1,0 +1,6 @@
+postgresql_install 'postgresql' do
+  version node['test']['pg_ver']
+  source :native
+
+  action %i(install_client)
+end

--- a/test/cookbooks/test/recipes/server_install_native.rb
+++ b/test/cookbooks/test/recipes/server_install_native.rb
@@ -1,0 +1,40 @@
+postgresql_install 'postgresql' do
+  version node['test']['pg_ver']
+  source :native
+  action %i(install init_server)
+end
+
+postgresql_config 'postgresql-server' do
+  version '15'
+
+  server_config({
+    'max_connections' => 110,
+    'shared_buffers' => '128MB',
+    'dynamic_shared_memory_type' => 'posix',
+    'max_wal_size' => '1GB',
+    'min_wal_size' => '80MB',
+    'log_destination' => 'stderr',
+    'logging_collector' => true,
+    'log_directory' => 'log',
+    'log_filename' => 'postgresql-%a.log',
+    'log_rotation_age' => '1d',
+    'log_rotation_size' => 0,
+    'log_truncate_on_rotation' => true,
+    'log_line_prefix' => '%m [%p]',
+    'log_timezone' => 'Etc/UTC',
+    'datestyle' => 'iso, mdy',
+    'timezone' => 'Etc/UTC',
+    'lc_messages' => 'C',
+    'lc_monetary' => 'C',
+    'lc_numeric' => 'C',
+    'lc_time' => 'C',
+    'default_text_search_config' => 'pg_catalog.english',
+  })
+
+  notifies :restart, 'postgresql_service[postgresql]', :delayed
+  action :create
+end
+
+postgresql_service 'postgresql' do
+  action %i(enable start)
+end

--- a/test/integration/client_install_native/controls/client_spec.rb
+++ b/test/integration/client_install_native/controls/client_spec.rb
@@ -1,0 +1,11 @@
+pg_ver = input('pg_ver')
+
+control 'postgresql-client-install' do
+  impact 1.0
+  desc 'These tests ensure a postgresql client installed correctly from distribution packages'
+
+  describe command('/usr/bin/psql -V') do
+    its('stdout') { should match(/psql \(PostgreSQL\) #{pg_ver}.\d/) }
+    its('exit_status') { should eq 0 }
+  end
+end

--- a/test/integration/client_install_native/inspec.yml
+++ b/test/integration/client_install_native/inspec.yml
@@ -1,0 +1,10 @@
+---
+name: client
+title: PostgreSQL client integration tests
+maintainer: Sous Chefs
+copyright_email: help@sous-chefs.org
+license: Apache
+summary: Check that the client is installed from distribution packages and working
+version: 0.0.1
+supports:
+  - os-family: unix

--- a/test/integration/server_install_native/controls/server_spec.rb
+++ b/test/integration/server_install_native/controls/server_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+pg_ver = input('pg_ver')
+
+if os[:family] == 'redhat' || os[:family] == 'fedora'
+  describe service("postgresql-#{pg_ver}") do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+else
+  describe service('postgresql') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/test/integration/server_install_native/inspec.yml
+++ b/test/integration/server_install_native/inspec.yml
@@ -1,0 +1,13 @@
+---
+name: server
+title: PostgreSQL server
+maintainer: Sous Chefs
+copyright_email: help@sous-chefs.org
+license: Apache
+summary: Verify the correct installation of the postgresql server from distribution packages
+version: 0.0.1
+supports:
+  - os-family: unix
+depends:
+  - name: client
+    path: ./test/integration/client_install


### PR DESCRIPTION
# Description

This PR allows to install the native distribution packages of PostgreSQL.

## Issues Resolved

- closes #709

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.