### PR TITLE
Fix parsing of address field in `pga_hba.conf` (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 - resolved cookstyle error: resources/role.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 - Fix connection to server via local socket
+- Fix parsing of address field in `pga_hba.conf`
 
 ## 11.0.1 - *2022-12-13*
 

--- a/libraries/access.rb
+++ b/libraries/access.rb
@@ -70,7 +70,7 @@ module PostgreSQL
 
           attr_reader :entries
 
-          SPLIT_REGEX = %r{^(?<type>\w+)\s+(?<database>\w+)\s+(?<user>\w+)\s+(?<address>[\d.:\/]+)?(?:\s*)(?<auth_method>[\w-]+)(?:\s*)(?<auth_options>[\w=-]+)?(?:\s*)(?<comment>#\s*.*)?$}.freeze
+          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>\w+)\s+(?<user>\w+))|((?!local)(?<type>\w+)\s+(?<database>\w+)\s+(?<user>\w+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?:\s*)(?<auth_options>[\w=-]+)?(?:\s*)(?<comment>#\s*.*)?$}.freeze
           private_constant :SPLIT_REGEX
 
           def initialize

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -65,3 +65,13 @@ postgresql_user 'dropable-user' do
 end
 
 file '/tmp/dropable-user.txt'
+
+postgresql_access 'access with hostname address' do
+  type 'host'
+  database 'all'
+  user 'hostname_user'
+  auth_method 'md5'
+  address 'host.domain'
+
+  notifies :restart, 'postgresql_service[postgresql]', :delayed
+end

--- a/test/integration/access/controls/base_access.rb
+++ b/test/integration/access/controls/base_access.rb
@@ -34,6 +34,18 @@ control 'postgresql-sous-chef-access' do
   end
 end
 
+control 'postgresql-hostname-access' do
+  impact 1.0
+  desc 'This test ensures hostnames may be specified in ACLs'
+
+  describe postgres_hba_conf.where { user == 'hostname_user' } do
+    its('database') { should cmp 'all' }
+    its('type') { should cmp 'host' }
+    its('auth_method') { should cmp 'md5' }
+    its('address') { should cmp 'host.domain' }
+  end
+end
+
 control 'sous_chef role should exist' do
   impact 1.0
   desc 'The sous_chef database user role should exist'


### PR DESCRIPTION
#  Description

Now also hostnames and `all` are allowed for the `address`-property of the `postgresql_access`-resource.

## Issues Resolved

* closes #712

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.