### PR TITLE
Access username regex fixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Fix regex not matching usernames containing characters other than word characters
+
 ## 11.1.1 - *2022-12-22*
 
 ## 11.1.0 - *2022-12-20*

--- a/libraries/access.rb
+++ b/libraries/access.rb
@@ -70,7 +70,7 @@ module PostgreSQL
 
           attr_reader :entries
 
-          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>\w+)\s+(?<user>\w+))|((?!local)(?<type>\w+)\s+(?<database>\w+)\s+(?<user>\w+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?:\s*)(?<auth_options>[\w=-]+)?(?:\s*)(?<comment>#\s*.*)?$}.freeze
+          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>\w+)\s+(?<user>[\w\d\-_.$]+))|((?!local)(?<type>\w+)\s+(?<database>\w+)\s+(?<user>[\w\d\-_.$]+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?:\s*)(?<auth_options>[\w=-]+)?(?:\s*)(?<comment>#\s*.*)?$}.freeze
           private_constant :SPLIT_REGEX
 
           def initialize

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -75,3 +75,13 @@ postgresql_access 'access with hostname address' do
 
   notifies :restart, 'postgresql_service[postgresql]', :delayed
 end
+
+postgresql_access 'access with hostname address username with dot' do
+  type 'host'
+  database 'all'
+  user 'hostname.user'
+  auth_method 'md5'
+  address 'host.domain'
+
+  notifies :restart, 'postgresql_service[postgresql]', :delayed
+end


### PR DESCRIPTION
# Description

- Fix regex not matching usernames containing characters other than word characters

## Issues Resolved

- Fixes #714

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
