### PR TITLE
Access fix for database name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Fix regex not matching databases names containing dashes and underscores
+- Update formatting output of pg_hba to support longer values
+
 ## 11.1.2 - *2023-01-12*
 
 - Fix regex not matching usernames containing characters other than word characters

--- a/libraries/access.rb
+++ b/libraries/access.rb
@@ -70,7 +70,7 @@ module PostgreSQL
 
           attr_reader :entries
 
-          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>\w+)\s+(?<user>[\w\d\-_.$]+))|((?!local)(?<type>\w+)\s+(?<database>\w+)\s+(?<user>[\w\d\-_.$]+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?:\s*)(?<auth_options>[\w=-]+)?(?:\s*)(?<comment>#\s*.*)?$}.freeze
+          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+))|((?!local)(?<type>\w+)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?:\s*)(?<auth_options>[\w=-]+)?(?:\s*)(?<comment>#\s*.*)?$}.freeze
           private_constant :SPLIT_REGEX
 
           def initialize
@@ -171,8 +171,8 @@ module PostgreSQL
 
           ENTRY_FIELD_FORMAT = {
             type: 8,
-            database: 16,
-            user: 16,
+            database: 32,
+            user: 32,
             address: 24,
             auth_method: 16,
             auth_options: 24,

--- a/templates/default/pg_hba.conf.erb
+++ b/templates/default/pg_hba.conf.erb
@@ -3,5 +3,5 @@
 # Do NOT modify this file by hand.
 #
 
-# TYPE  DATABASE        USER            ADDRESS                 METHOD         OPTIONS
+# TYPE  DATABASE                        USER                            ADDRESS                 METHOD         OPTIONS
 <%= @pg_hba.to_s %>

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -85,3 +85,13 @@ postgresql_access 'access with hostname address username with dot' do
 
   notifies :restart, 'postgresql_service[postgresql]', :delayed
 end
+
+postgresql_access 'access with database name with an underscore' do
+  type 'host'
+  database 'my_database'
+  user 'hostname.user'
+  auth_method 'md5'
+  address 'host.domain'
+
+  notifies :restart, 'postgresql_service[postgresql]', :delayed
+end


### PR DESCRIPTION
# Description

Also, formatting for pg_hba did not support long names for databases and usernames (often goes with dashes and underscores) so I updated the formatting options

## Issues Resolved

Handling databases names with `-` and `_`

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
