### PR TITLE
Allow database encoding to be specified as a String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Allow database encoding to be specified as a String
+
 ## 11.1.6 - *2023-02-19*
 
 Standardise files with files in sous-chefs/repo-management

--- a/libraries/sql/database.rb
+++ b/libraries/sql/database.rb
@@ -82,7 +82,7 @@ module PostgreSQL
             properties.each do |p|
               next if nil_or_empty?(new_resource.send(p))
 
-              property_string = if %i(allow_connections connection_limit is_template).include?(p)
+              property_string = if %i(allow_connections connection_limit is_template).include?(p) || p.is_a?(Integer)
                                   "#{p.to_s.upcase}=#{new_resource.send(p)}"
                                 else
                                   "#{p.to_s.upcase}=\"#{new_resource.send(p)}\""

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -28,7 +28,7 @@ property :template, String,
           default: 'template1',
           description: 'The name of the template from which to create the new database, or DEFAULT to use the default template (template1)'
 
-property :encoding, Integer,
+property :encoding, [Integer, String],
           description: 'Character set encoding to use in the new database'
 
 property :strategy, String,

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -36,7 +36,10 @@ postgresql_user 'sous_chef' do
   action :update
 end
 
-postgresql_database 'sous_chef'
+postgresql_database 'sous_chef' do
+  template 'template0'
+  encoding 'utf8'
+end
 
 postgresql_access 'a sous_chef local superuser' do
   type 'host'

--- a/test/integration/access/controls/base_access.rb
+++ b/test/integration/access/controls/base_access.rb
@@ -89,3 +89,14 @@ control 'name-with-dash role has statement_timeout set to 8mins' do
     its('output') { should cmp /statement_timeout=8min/ }
   end
 end
+
+control 'database sous_chef should exist with encoding UTF8' do
+  impact 1.0
+  desc 'Ensures database exists and encoding is correct'
+
+  postgres_access = postgres_session('postgres', '12345', '127.0.0.1')
+
+  describe postgres_access.query("SELECT encoding from pg_database WHERE datname='sous_chef';") do
+    its('output') { should eql '6' }
+  end
+end


### PR DESCRIPTION
# Description

Allow database encoding to be specified as a String

## Issues Resolved

n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
