### PR TITLE
OS package support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           - "server-install-13"
           - "server-install-14"
           - "server-install-15"
+          - "server-install-os"
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Allow package installation from OS distribution repository
+
 ## 11.2.12 - *2023-05-16*
 
 ## 11.2.11 - *2023-05-04*

--- a/documentation/postgresql_install.md
+++ b/documentation/postgresql_install.md
@@ -21,7 +21,7 @@
 | ---------------------------------- | ----- | --------------- | ------- | ------------------------------------------------ | -------------- |
 | `sensitive`                        |       | true, false     |         |                                                  |                |
 | `version`                          |       | String, Integer |         | Version to install                               |                |
-| `source`                           |       | String, Symbol  |         | Installation source                              | repo           |
+| `source`                           |       | String, Symbol  |         | Installation source                              | repo, os       |
 | `client_packages`                  |       | String, Array   |         | Client packages to install                       |                |
 | `server_packages`                  |       | String, Array   |         | Server packages to install                       |                |
 | `repo_pgdg`                        |       | true, false     |         | Create pgdg repo                                 |                |

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -33,6 +33,13 @@ platforms:
   - name: ubuntu-22.04
 
 suites:
+  - name: server_install_os
+    verifier:
+      inspec_tests:
+        - path: test/integration/server_install_os/
+    run_list:
+      - recipe[test::server_install_os]
+
   - name: access_15
     attributes:
       test:

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -94,15 +94,24 @@ action :create do
       action :create
     end
 
+    service_dir = case installed_postgresql_package_source
+                  when :os
+                    '/etc/systemd/system/postgresql.service.d'
+                  when :repo
+                    "/etc/systemd/system/postgresql-#{new_resource.version}.service.d"
+                  else
+                    raise ArgumentError, "Unknown installation source: #{installed_postgresql_package_source}"
+                  end
+
     if new_resource.external_pid_file
-      directory "/etc/systemd/system/postgresql-#{new_resource.version}.service.d" do
+      directory service_dir do
         owner 'root'
         group 'root'
         mode '0755'
         action :create
       end
 
-      template "/etc/systemd/system/postgresql-#{new_resource.version}.service.d/10-pid.conf" do
+      template "#{service_dir}/10-pid.conf" do
         cookbook new_resource.cookbook
         source 'systemd/10-pid.conf.erb'
 
@@ -117,8 +126,8 @@ action :create do
         action :create
       end
     else
-      directory("/etc/systemd/system/postgresql-#{new_resource.version}.service.d") { action(:delete) }
-      file("/etc/systemd/system/postgresql-#{new_resource.version}.service.d") { action(:delete) }
+      directory(service_dir) { action(:delete) }
+      file("#{service_dir}/10-pid.conf") { action(:delete) }
     end
   end
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -30,16 +30,16 @@ property :version, [String, Integer],
 property :source, [String, Symbol],
           default: :repo,
           coerce: proc { |p| p.to_sym },
-          equal_to: %i(repo),
+          equal_to: %i(repo os),
           description: 'Installation source'
 
 property :client_packages, [String, Array],
-          default: lazy { default_client_packages },
+          default: lazy { default_client_packages(version: version, source: source) },
           coerce: proc { |p| Array(p) },
           description: 'Client packages to install'
 
 property :server_packages, [String, Array],
-          default: lazy { default_server_packages },
+          default: lazy { default_server_packages(version: version, source: source) },
           coerce: proc { |p| Array(p) },
           description: 'Server packages to install'
 
@@ -187,6 +187,8 @@ action_class do
     end
 
     ohai 'postgresql_client_packages' do
+      plugin 'packages'
+
       action :nothing
     end
   end
@@ -205,6 +207,8 @@ action_class do
     end
 
     ohai 'postgresql_server_packages' do
+      plugin 'packages'
+
       action :nothing
     end
   end
@@ -267,7 +271,7 @@ end
 action :init_server do
   return if initialized? || !platform_family?('rhel', 'fedora', 'amazon')
 
-  converge_by('Init Postgresql DB') do
+  converge_by('Init PostgreSQL') do
     execute 'init_db' do
       command rhel_init_db_command(new_resource)
       user new_resource.initdb_user

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -13,19 +13,35 @@ RSpec.describe PostgreSQL::Cookbook::Helpers do
         allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
       end
 
-      context "with rhel family and Postgres #{pg_version}" do
+      context "with rhel family and Postgres #{pg_version} from repo" do
         let(:platform_family) { 'rhel' }
 
         it 'returns the correct path' do
-          expect(subject.data_dir(pg_version)).to eq "/var/lib/pgsql/#{pg_version}/data"
+          expect(subject.data_dir(version: pg_version, source: :repo)).to eq "/var/lib/pgsql/#{pg_version}/data"
         end
       end
 
-      context "with debian family and Postgres #{pg_version}" do
+      context "with rhel family and Postgres #{pg_version} from os" do
+        let(:platform_family) { 'rhel' }
+
+        it 'returns the correct path' do
+          expect(subject.data_dir(version: pg_version, source: :os)).to eq '/var/lib/pgsql/data'
+        end
+      end
+
+      context "with debian family and Postgres #{pg_version} from repo" do
         let(:platform_family) { 'debian' }
 
         it 'returns the correct path' do
-          expect(subject.data_dir(pg_version)).to eq "/var/lib/postgresql/#{pg_version}/main"
+          expect(subject.data_dir(version: pg_version, source: :repo)).to eq "/var/lib/postgresql/#{pg_version}/main"
+        end
+      end
+
+      context "with debian family and Postgres #{pg_version} from os" do
+        let(:platform_family) { 'debian' }
+
+        it 'returns the correct path' do
+          expect(subject.data_dir(version: pg_version, source: :os)).to eq "/var/lib/postgresql/#{pg_version}/main"
         end
       end
     end
@@ -35,19 +51,35 @@ RSpec.describe PostgreSQL::Cookbook::Helpers do
         allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
       end
 
-      context "with rhel family and Postgres #{pg_version}" do
+      context "with rhel family and Postgres #{pg_version} from repo" do
         let(:platform_family) { 'rhel' }
 
         it 'returns the correct path' do
-          expect(subject.conf_dir(pg_version)).to eq "/var/lib/pgsql/#{pg_version}/data"
+          expect(subject.conf_dir(version: pg_version, source: :repo)).to eq "/var/lib/pgsql/#{pg_version}/data"
         end
       end
 
-      context "with debian family and Postgres #{pg_version}" do
+      context "with rhel family and Postgres #{pg_version} from os" do
+        let(:platform_family) { 'rhel' }
+
+        it 'returns the correct path' do
+          expect(subject.conf_dir(version: pg_version, source: :os)).to eq '/var/lib/pgsql/data'
+        end
+      end
+
+      context "with debian family and Postgres #{pg_version} from repo" do
         let(:platform_family) { 'debian' }
 
         it 'returns the correct path' do
-          expect(subject.conf_dir(pg_version)).to eq "/etc/postgresql/#{pg_version}/main"
+          expect(subject.conf_dir(version: pg_version, source: :repo)).to eq "/etc/postgresql/#{pg_version}/main"
+        end
+      end
+
+      context "with debian family and Postgres #{pg_version} from os" do
+        let(:platform_family) { 'debian' }
+
+        it 'returns the correct path' do
+          expect(subject.conf_dir(version: pg_version, source: :os)).to eq "/etc/postgresql/#{pg_version}/main"
         end
       end
     end
@@ -57,19 +89,35 @@ RSpec.describe PostgreSQL::Cookbook::Helpers do
         allow(subject).to receive(:[]).with(:platform_family).and_return(platform_family)
       end
 
-      context "with rhel family and Postgres #{pg_version}" do
+      context "with rhel family and Postgres #{pg_version} from repo" do
         let(:platform_family) { 'rhel' }
 
         it 'returns the correct service name' do
-          expect(subject.default_platform_service_name(pg_version)).to eq "postgresql-#{pg_version}"
+          expect(subject.default_platform_service_name(version: pg_version, source: :repo)).to eq "postgresql-#{pg_version}"
         end
       end
 
-      context "with debian family and Postgres #{pg_version}" do
+      context "with rhel family and Postgres #{pg_version} from os" do
+        let(:platform_family) { 'rhel' }
+
+        it 'returns the correct service name' do
+          expect(subject.default_platform_service_name(version: pg_version, source: :os)).to eq 'postgresql'
+        end
+      end
+
+      context "with debian family and Postgres #{pg_version} from repo" do
         let(:platform_family) { 'debian' }
 
         it 'returns the correct service name' do
-          expect(subject.default_platform_service_name(pg_version)).to eq 'postgresql'
+          expect(subject.default_platform_service_name(version: pg_version, source: :repo)).to eq 'postgresql'
+        end
+      end
+
+      context "with debian family and Postgres #{pg_version} from os" do
+        let(:platform_family) { 'debian' }
+
+        it 'returns the correct service name' do
+          expect(subject.default_platform_service_name(version: pg_version, source: :os)).to eq 'postgresql'
         end
       end
     end

--- a/test/cookbooks/test/recipes/server_install_os.rb
+++ b/test/cookbooks/test/recipes/server_install_os.rb
@@ -1,0 +1,34 @@
+postgresql_install 'postgresql' do
+  source :os
+  action %i(install init_server)
+end
+
+postgresql_config 'postgresql-server' do
+  server_config({
+    'max_connections' => 110,
+    'shared_buffers' => '128MB',
+    'log_destination' => 'stderr',
+    'logging_collector' => true,
+    'log_directory' => 'log',
+    'log_filename' => 'postgresql-%a.log',
+    'log_rotation_age' => '1d',
+    'log_rotation_size' => 0,
+    'log_truncate_on_rotation' => true,
+    'log_line_prefix' => '%m [%p]',
+    'log_timezone' => 'Etc/UTC',
+    'datestyle' => 'iso, mdy',
+    'timezone' => 'Etc/UTC',
+    'lc_messages' => 'C',
+    'lc_monetary' => 'C',
+    'lc_numeric' => 'C',
+    'lc_time' => 'C',
+    'default_text_search_config' => 'pg_catalog.english',
+  })
+
+  notifies :restart, 'postgresql_service[postgresql]', :delayed
+  action :create
+end
+
+postgresql_service 'postgresql' do
+  action %i(enable start)
+end

--- a/test/integration/server_install_os/controls/server_spec.rb
+++ b/test/integration/server_install_os/controls/server_spec.rb
@@ -1,0 +1,5 @@
+describe service('postgresql') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end

--- a/test/integration/server_install_os/inspec.yml
+++ b/test/integration/server_install_os/inspec.yml
@@ -1,0 +1,13 @@
+---
+name: server
+title: PostgreSQL server
+maintainer: Sous Chefs
+copyright_email: help@sous-chefs.org
+license: Apache
+summary: Verify the correct installation of the postgresql server
+version: 0.0.1
+supports:
+  - os-family: unix
+# depends:
+#   - name: client
+#     path: ./test/integration/client_install


### PR DESCRIPTION
# Description

This PR allows to install native PostgreSQL packages from the OS distributors package repository. This PR is based on @bmhughes work. I would like to withdraw #710 in favour of his approach. I tested it against Debian 11 and CentOS 7 and it works as expected. From my point of view it looks ready to merge as it solves #709 and I couldn't identify any issues remaining.

## Issues Resolved

 * #709

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
