### PR TITLE
Allow to configure auth method with complex/multiple option(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Allow to configure auth method with complex/multiple option(s)
+
 ## 11.3.0 - *2023-06-06*
 
 - Allow package installation from OS distribution repository

--- a/libraries/_utils.rb
+++ b/libraries/_utils.rb
@@ -18,7 +18,23 @@
 module PostgreSQL
   module Cookbook
     module Utils
+      AUTH_OPTION_REGEX = /[\w-]+=(?:"[^"]*"|[^\s"]+)/.freeze
+
       private
+
+      # Converts the given HBA auth-options Hash or String into its sorted string version
+      #
+      # @return [string] the alphanumerically sorted list of auth-options
+      def sorted_auth_options_string(value)
+        case value
+        when ::Hash
+          value.map { |k, v| "#{k}=#{v}" }.sort!.join(' ')
+        when ::String
+          value.scan(AUTH_OPTION_REGEX).sort!.join(' ')
+        else
+          raise ::ArgumentError, "Only ::Hash & ::String are supported, #{value.class} given."
+        end
+      end
 
       # Check if a given object(s) are either Nil or Empty
       #

--- a/libraries/access.rb
+++ b/libraries/access.rb
@@ -70,8 +70,7 @@ module PostgreSQL
 
           attr_reader :entries
 
-          AUTH_OPTION_REGEX = /[\w-]+=(?:"[^"]*"|[^\s"]+)/.freeze
-          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+))|((?!local)(?<type>\w+)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?:\s*)(?<auth_options>#{AUTH_OPTION_REGEX})*(?:\s*)(?<comment>#\s*.*)?$}.freeze
+          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+))|((?!local)(?<type>\w+)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?<auth_options>(?:\s+#{AUTH_OPTION_REGEX})*)(?:\s*)(?<comment>#\s*.*)?$}.freeze
           private_constant :SPLIT_REGEX
 
           def initialize
@@ -211,7 +210,7 @@ module PostgreSQL
 
           def update(auth_method: nil, auth_options: nil, comment: nil)
             @auth_method = auth_method if auth_method
-            @auth_options = PgHbaFileEntryAuthOptions.new(auth_options) if auth_options
+            @auth_options = PgHbaFileEntryAuthOptions.new(auth_options) if auth_options && !auth_options.empty?
             self.comment = comment if comment
 
             self
@@ -250,8 +249,7 @@ module PostgreSQL
             @database = database
             @user = user
             @auth_method = auth_method
-            @auth_options = auth_options
-            @auth_options = PgHbaFileEntryAuthOptions.new(auth_options) if auth_options
+            @auth_options = PgHbaFileEntryAuthOptions.new(auth_options) if auth_options && !auth_options.empty?
             self.comment = comment
           end
 
@@ -277,8 +275,7 @@ module PostgreSQL
             @user = user
             @address = address
             @auth_method = auth_method
-            @auth_options = auth_options
-            @auth_options = PgHbaFileEntryAuthOptions.new(auth_options) if auth_options
+            @auth_options = PgHbaFileEntryAuthOptions.new(auth_options) if auth_options && !auth_options.empty?
             self.comment = comment
           end
 
@@ -288,6 +285,8 @@ module PostgreSQL
         end
 
         class PgHbaFileEntryAuthOptions
+          include PostgreSQL::Cookbook::Utils
+
           attr_reader :options
 
           def initialize(options_string)
@@ -322,7 +321,7 @@ module PostgreSQL
           private
 
           def options_string_parse(string)
-            string.scan(PgHbaFile::AUTH_OPTION_REGEX).sort!.map! { |s| s.split('=', 2) }
+            string.scan(AUTH_OPTION_REGEX).sort!.map! { |s| s.split('=', 2) }
           end
         end
 

--- a/libraries/access.rb
+++ b/libraries/access.rb
@@ -70,7 +70,8 @@ module PostgreSQL
 
           attr_reader :entries
 
-          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+))|((?!local)(?<type>\w+)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?:\s*)(?<auth_options>[\w=-]+)?(?:\s*)(?<comment>#\s*.*)?$}.freeze
+          AUTH_OPTION_REGEX = /[\w-]+=(?:"[^"]*"|[^\s"]+)/.freeze
+          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+))|((?!local)(?<type>\w+)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?:\s*)(?<auth_options>#{AUTH_OPTION_REGEX})*(?:\s*)(?<comment>#\s*.*)?$}.freeze
           private_constant :SPLIT_REGEX
 
           def initialize
@@ -321,7 +322,7 @@ module PostgreSQL
           private
 
           def options_string_parse(string)
-            string.split.map { |kv| kv.split('=') }.sort
+            string.scan(PgHbaFile::AUTH_OPTION_REGEX).sort!.map! { |s| s.split('=', 2) }
           end
         end
 

--- a/resources/access.rb
+++ b/resources/access.rb
@@ -47,7 +47,7 @@ property :auth_method, String,
           description: 'Access record authentication method'
 
 property :auth_options, [String, Hash],
-          coerce: proc { |p| p.is_a?(Hash) ? p.map { |k, v| "#{k}=#{v}" }.join(' ') : p },
+          coerce: proc { |v| sorted_auth_options_string(v) },
           description: 'Access record authentication options'
 
 property :comment, String,

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -108,3 +108,12 @@ postgresql_access 'access with hostname long' do
 
   notifies :restart, 'postgresql_service[postgresql]', :delayed
 end
+
+postgresql_access 'access with urls as auth_options' do
+  type 'host'
+  database 'all'
+  user 'ldap_url.user'
+  address '127.0.0.1/32'
+  auth_method 'ldap'
+  auth_options 'ldapurl="ldap://ldap.example.net/dc=example,dc=net?uid?sub"'
+end

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -117,3 +117,14 @@ postgresql_access 'access with urls as auth_options' do
   auth_method 'ldap'
   auth_options 'ldapurl="ldap://ldap.example.net/dc=example,dc=net?uid?sub"'
 end
+
+postgresql_access 'access with several auth_options' do
+  type 'host'
+  database 'all'
+  user 'ldap_options.user'
+  address '127.0.0.1/32'
+  auth_method 'ldap'
+  auth_options ldapserver: 'ldap.example.net',
+               ldapbasedn: '"dc=example, dc=net"',
+               ldapsearchattribute: 'uid'
+end

--- a/test/integration/access/controls/base_access.rb
+++ b/test/integration/access/controls/base_access.rb
@@ -112,3 +112,17 @@ control 'database sous_chef should exist with encoding UTF8' do
     its('output') { should eql '6' }
   end
 end
+
+control 'postgresql-access-auth_options-with-url' do
+  impact 1.0
+  desc 'This test ensures URL may be specified in auth_options'
+
+  describe postgres_hba_conf.where { user == 'ldap_url.user' } do
+    its('type') { should cmp 'host' }
+    its('database') { should cmp 'all' }
+    its('user') { should cmp 'ldap_url.user' }
+    its('address') { should cmp '127.0.0.1/32' }
+    its('auth_method') { should cmp 'ldap' }
+    its('auth_params') { should cmp 'ldapurl="ldap://ldap.example.net/dc=example,dc=net?uid?sub"' }
+  end
+end

--- a/test/integration/access/controls/base_access.rb
+++ b/test/integration/access/controls/base_access.rb
@@ -126,3 +126,17 @@ control 'postgresql-access-auth_options-with-url' do
     its('auth_params') { should cmp 'ldapurl="ldap://ldap.example.net/dc=example,dc=net?uid?sub"' }
   end
 end
+
+control 'postgresql-access-multiple-auth_options' do
+  impact 1.0
+  desc 'This test ensures multiple auth_options may  be specified'
+
+  describe postgres_hba_conf.where { user == 'ldap_options.user' } do
+    its('type') { should cmp 'host' }
+    its('database') { should cmp 'all' }
+    its('user') { should cmp 'ldap_options.user' }
+    its('address') { should cmp '127.0.0.1/32' }
+    its('auth_method') { should cmp 'ldap' }
+    its('auth_params') { should cmp 'ldapbasedn="dc=example, dc=net" ldapsearchattribute=uid ldapserver=ldap.example.net' }
+  end
+end


### PR DESCRIPTION
# Description

Some auth methods require complex options, for instance the `ldap` configuration requires either:
- a complex single option `ldapurl`
- several simpler options

Both solutions were not possible with former Regex in the HBA helper lib, as:
- in the single option case, some characters were forbidden
- in the other case, multiple options was just not possible



This PR allows to specify multiple `auth_options` values and to use any non-space characters.


## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
