### PR TITLE
Fix: allow multiple users/databases in postgresql_access resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Allow to configure multiple databases and users in one `pg_hba.conf` entry
+
 ## 11.5.1 - *2023-06-26*
 
 - Fix typo in documentation of `postgresql_extension` resource

--- a/libraries/access.rb
+++ b/libraries/access.rb
@@ -70,7 +70,7 @@ module PostgreSQL
 
           attr_reader :entries
 
-          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+))|((?!local)(?<type>\w+)\s+(?<database>[\w\-_]+)\s+(?<user>[\w\d\-_.$]+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?<auth_options>(?:\s+#{AUTH_OPTION_REGEX})*)(?:\s*)(?<comment>#\s*.*)?$}.freeze
+          SPLIT_REGEX = %r{^(((?<type>local)\s+(?<database>[\w\-_,]+)\s+(?<user>[\w\d\-_.$,]+))|((?!local)(?<type>\w+)\s+(?<database>[\w\-_,]+)\s+(?<user>[\w\d\-_.$,]+)\s+(?<address>[\w\-.:\/]+)))\s+(?<auth_method>[\w-]+)(?<auth_options>(?:\s+#{AUTH_OPTION_REGEX})*)(?:\s*)(?<comment>#\s*.*)?$}.freeze
           private_constant :SPLIT_REGEX
 
           def initialize

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -128,3 +128,11 @@ postgresql_access 'access with several auth_options' do
                ldapbasedn: '"dc=example, dc=net"',
                ldapsearchattribute: 'uid'
 end
+
+postgresql_access 'access with multiple databases' do
+  type 'host'
+  database 'foo,bar'
+  user 'john,doe'
+  address '127.0.0.1/32'
+  auth_method 'md5'
+end


### PR DESCRIPTION
# Description

PostgreSQL pg_hba.conf allows to specify multiple databases and users in one entry. They are seperated by comma. This fixes the regex which parses pg_hba.conf entries to match multiple databases or users in one entry.

## Issues Resolved

closes #750

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
