### PR TITLE
Prevent triggering resource changes if file mode of postgresql.conf doesn't change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Prevent `postgresql_config` resource from triggering changes, if `filemode`,
+  `owner` or `group` are specified, but there values don't change.
+
 ## 11.6.1 - *2023-07-09*
 
 ## 11.6.0 - *2023-07-07*

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -54,6 +54,12 @@ property :server_config, Hash,
 load_current_value do |new_resource|
   current_value_does_not_exist! unless ::File.exist?(new_resource.config_file)
 
+  if ::File.exist?(new_resource.config_file)
+    owner ::Etc.getpwuid(::File.stat(new_resource.config_file).uid).name
+    group ::Etc.getgrgid(::File.stat(new_resource.config_file).gid).name
+    filemode ::File.stat(new_resource.config_file).mode.to_s(8)[-4..-1]
+  end
+
   postgresql_server_config = PostgreSQL::Cookbook::ConfigHelpers.postgresql_conf_load_file(new_resource.config_file).fetch('global').deep_sort
   postgresql_server_config.transform_values! { |v| v.is_a?(String) ? v.gsub("'", '') : v }
 


### PR DESCRIPTION
# Description

When using the properties `filemode`, `owner` and `group` in the `postgresql_config`, the resource is considered as changed in every Chef client run. This PR adopts the code from the `postgresql_access` and `postgresql_ident` resource, which prevent this erroneous behavior at these resources.

## Issues Resolved

N/A

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
