### PR TITLE
[GH-745] - fix PostgreSQL version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Fix PostgreSQL version detection
+
 ## 11.6.2 - *2023-07-24*
 
 - Prevent `postgresql_config` resource from triggering changes, if `filemode`,

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -24,7 +24,7 @@ module PostgreSQL
       include Utils
 
       def installed_postgresql_major_version
-        pgsql_package = node['packages'].filter { |p| p.match?(/postgresql-?(\d+)?$/) }
+        pgsql_package = node['packages'].filter { |p| p.match?(/^postgresql-?(\d+)?$/) }
 
         raise 'Unable to determine installed PostgreSQL version' if nil_or_empty?(pgsql_package)
 


### PR DESCRIPTION
# Description

This PR fixes the detection of the installed PostgreSQL version. The current regex isn't specific enough and accepts packages other than PostgreSQL as well.

## Issues Resolved

- #745

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
