### PR TITLE
Add insert position option for access resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Add insert position option for access resources
+- Refactor ident class to use update method to empty properties overwriting settings on update
+
 ## 11.6.3 - *2023-07-25*
 
 - Fix PostgreSQL version detection

--- a/libraries/access.rb
+++ b/libraries/access.rb
@@ -101,10 +101,15 @@ module PostgreSQL
             @entries.map(&:to_s).join("\n")
           end
 
-          def add(entry)
+          def add(entry, position = nil)
             raise PgHbaInvalidEntryType unless entry.is_a?(PgHbaFileEntry)
 
-            @entries.push(entry)
+            if position
+              @entries.insert(position, entry)
+            else
+              @entries.push(entry)
+            end
+
             @entries.uniq!
           end
 

--- a/libraries/ident.rb
+++ b/libraries/ident.rb
@@ -82,6 +82,7 @@ module PostgreSQL
             return false if entry?(entry.map_name)
 
             @entries.push(entry)
+
             sort!
           end
 
@@ -168,8 +169,7 @@ module PostgreSQL
         class PgIdentFileEntry
           include PostgreSQL::Cookbook::Utils
 
-          attr_accessor :map_name, :system_username, :database_username
-          attr_reader :comment
+          attr_reader :map_name, :system_username, :database_username, :comment
 
           ENTRY_FIELD_FORMAT = {
             map_name: 16,
@@ -205,6 +205,14 @@ module PostgreSQL
             return true if self.class.const_get(:ENTRY_FIELDS).all? { |field| send(field).eql?(entry.send(field)) }
 
             false
+          end
+
+          def update(system_username:, database_username:, comment:)
+            @system_username = system_username if system_username
+            @database_username = database_username if database_username
+            self.comment = comment if comment
+
+            self
           end
 
           def comment=(comment)

--- a/resources/access.rb
+++ b/resources/access.rb
@@ -54,6 +54,9 @@ property :comment, String,
           coerce: proc { |p| p.start_with?('#') ? p : "# #{p}" },
           description: 'Access record comment'
 
+property :position, Integer,
+          description: 'Insert position for entry creation'
+
 load_current_value do |new_resource|
   current_value_does_not_exist! unless ::File.exist?(new_resource.config_file)
 
@@ -87,7 +90,7 @@ action :create do
     if nil_or_empty?(entry)
       resource_properties = %i(type database user address auth_method auth_options comment).map { |p| [ p, new_resource.send(p) ] }.to_h.compact
       entry = PostgreSQL::Cookbook::AccessHelpers::PgHba::PgHbaFileEntry.create(**resource_properties)
-      config_resource.variables[:pg_hba].add(entry)
+      config_resource.variables[:pg_hba].add(entry, new_resource.position)
     else
       entry.update(auth_method: new_resource.auth_method, auth_options: new_resource.auth_options, comment: new_resource.comment)
     end

--- a/resources/ident.rb
+++ b/resources/ident.rb
@@ -72,9 +72,7 @@ action :create do
       entry = PostgreSQL::Cookbook::IdentHelpers::PgIdent::PgIdentFileEntry.new(**resource_properties)
       config_resource.variables[:pg_ident].add(entry)
     else
-      entry.system_username = new_resource.system_username
-      entry.database_username = new_resource.database_username
-      entry.comment = new_resource.comment
+      entry.update(system_username: new_resource.system_username, database_username: new_resource.database_username, comment: new_resource.comment)
     end
   end
 end
@@ -86,9 +84,7 @@ action :update do
 
     raise Chef::Exceptions::CurrentValueDoesNotExist, "Cannot update ident entry for '#{new_resource.map_name}' as it does not exist" if nil_or_empty?(entry)
 
-    entry.system_username = new_resource.system_username
-    entry.database_username = new_resource.database_username
-    entry.comment = new_resource.comment
+    entry.update(system_username: new_resource.system_username, database_username: new_resource.database_username, comment: new_resource.comment)
   end
 end
 


### PR DESCRIPTION
# Description

- Add insert position option for access resources
- Refactor ident class to use update method to empty properties overwriting settings on update

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
