### PR TITLE
Update yum GPG file location

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -132,6 +132,22 @@ module PostgreSQL
         end
       end
 
+      def default_yum_gpg_key_uri
+        case node['platform_family']
+        when 'rhel', 'amazon'
+          case node['platform_version'].to_i
+          when 7
+            'https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL7'
+          else
+            'https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL'
+          end
+        when 'fedora'
+          'https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-Fedora'
+        else
+          'https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG'
+        end
+      end
+
       def dnf_module_platform?
         (platform_family?('rhel') && node['platform_version'].to_i == 8) || platform_family?('fedora')
       end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -64,7 +64,7 @@ property :repo_pgdg_source_updates_testing, [true, false],
           description: 'Create pgdg-source-updates-testing repo'
 
 property :yum_gpg_key_uri, String,
-          default: 'https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG',
+          default: lazy { default_yum_gpg_key_uri },
           description: 'YUM/DNF GPG key URL'
 
 property :apt_gpg_key_uri, String,
@@ -94,7 +94,7 @@ action_class do
   def do_repository_action(repo_action)
     case node['platform_family']
     when 'rhel', 'fedora', 'amazon'
-      remote_file '/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG' do
+      remote_file '/etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY' do
         source new_resource.yum_gpg_key_uri
         sensitive new_resource.sensitive
       end
@@ -109,7 +109,7 @@ action_class do
         baseurl yum_repo_url('https://download.postgresql.org/pub/repos/yum')
         enabled new_resource.repo_pgdg
         gpgcheck true
-        gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
+        gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
       end
 
@@ -119,7 +119,7 @@ action_class do
         baseurl yum_common_repo_url
         enabled new_resource.repo_pgdg_common
         gpgcheck true
-        gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
+        gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
       end
 
@@ -130,7 +130,7 @@ action_class do
         make_cache false
         enabled new_resource.repo_pgdg_source
         gpgcheck true
-        gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
+        gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
       end
 
@@ -141,7 +141,7 @@ action_class do
         make_cache false
         enabled new_resource.repo_pgdg_updates_testing
         gpgcheck true
-        gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
+        gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
       end
 
@@ -152,7 +152,7 @@ action_class do
         make_cache false
         enabled new_resource.repo_pgdg_source_updates_testing
         gpgcheck true
-        gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG'
+        gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
       end
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -64,7 +64,7 @@ property :repo_pgdg_source_updates_testing, [true, false],
           description: 'Create pgdg-source-updates-testing repo'
 
 property :yum_gpg_key_uri, String,
-          default: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG',
+          default: 'https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG',
           description: 'YUM/DNF GPG key URL'
 
 property :apt_gpg_key_uri, String,


### PR DESCRIPTION
# Description

Different operating systems now may require a different key and the default 'RPM-GPG-KEY-PGDG' key is no longer universally accepted for the yum PG packages. I created a helper function to sort and select the GPG key based on the OS and return the correct path.

## Issues Resolved

N/A

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
