### PR TITLE
Allow specification of apt repository URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Add `apt_repository_uri` property to `postgresql_install` resource
+
 ## 11.10.0 - *2024-01-24*
 
 - Modify installed_postgresql_package_source to get highest PG version from packages

--- a/documentation/postgresql_install.md
+++ b/documentation/postgresql_install.md
@@ -30,6 +30,7 @@
 | `repo_pgdg_updates_testing`        |       | true, false     |         | Create pgdg-updates-testing repo                 |                |
 | `repo_pgdg_source_updates_testing` |       | true, false     |         | Create pgdg-source-updates-testing repo          |                |
 | `yum_gpg_key_uri`                  |       | String          |         | YUM/DNF GPG key URL                              |                |
+| `apt_repository_uri`               |       | String          |         | apt repository URL                               |                |
 | `apt_gpg_key_uri`                  |       | String          |         | apt GPG key URL                                  |                |
 | `initdb_additional_options`        |       | String          |         | Additional options to pass to the initdb command |                |
 | `initdb_locale`                    |       | String          |         | Locale to use for the initdb command             |                |

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -67,6 +67,10 @@ property :yum_gpg_key_uri, String,
           default: lazy { default_yum_gpg_key_uri },
           description: 'YUM/DNF GPG key URL'
 
+property :apt_repository_uri, String,
+          default: 'https://download.postgresql.org/pub/repos/apt/',
+          description: 'apt repository URL'
+
 property :apt_gpg_key_uri, String,
           default: 'https://download.postgresql.org/pub/repos/apt/ACCC4CF8.asc',
           description: 'apt GPG key URL'
@@ -162,7 +166,7 @@ action_class do
       package 'apt-transport-https'
 
       apt_repository "postgresql_org_repository_#{new_resource.version.to_s}" do
-        uri 'https://download.postgresql.org/pub/repos/apt/'
+        uri new_resource.apt_repository_uri
         components ['main', new_resource.version.to_s]
         distribution "#{node['lsb']['codename']}-pgdg"
         key new_resource.apt_gpg_key_uri


### PR DESCRIPTION
# Description

This allows specification of a different apt repository url to allow for proxied sources.

## Issues Resolved

NA

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
