### PR TITLE
Bump deepsort fuzzy dependency to 0.5.0 to match latest upstream release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Bump deepsort fuzzy dependency to 0.5.0 to match latest upstream release
+
 ## 11.10.2 - *2024-05-03*
 
 ## 11.10.1 - *2024-01-31*

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ chef_version      '>= 16.0'
 
 depends 'yum', '>= 7.2.0'
 
-gem 'deepsort', '~> 0.4.5'
+gem 'deepsort', '~> 0.5.0'
 gem 'inifile', '~> 3.0'
 
 supports 'amazon'


### PR DESCRIPTION
Signed-off-by: Lance Albertson <lance@osuosl.org>
