### PR TITLE
Bugfix/oracle crb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Standardise files with files in sous-chefs/repo-management
 
 Standardise files with files in sous-chefs/repo-management
 
+- Fix installation of `pg` gem build dependency `perl-IPC-Run` on oracle linux 9
+
 ## 11.10.3 - *2024-05-03*
 
 - Bump deepsort fuzzy dependency to 0.5.0 to match latest upstream release

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,10 +1,14 @@
 driver:
   name: dokken
   privileged: true
+  chef_image: <%= ENV['CHEF_IMAGE'] || 'chef/chef' %>
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  project_name: <%= ENV['PROJECT_NAME'] || 'chef' %>
+  chef_binary: <%= ENV['CHEF_BINARY'] || '/opt/chef/bin/chef-client' %>
 
 platforms:
   - name: almalinux-8

--- a/libraries/sql/_connection.rb
+++ b/libraries/sql/_connection.rb
@@ -90,9 +90,8 @@ module PostgreSQL
               declare_resource(:package, libpq_package_name) { compile_time(true) }
               declare_resource(:package, 'perl-IPC-Run') do
                 compile_time(true)
-                case node['platform']
-                when 'oracle'
-                  options ["--enablerepo=ol9_codeready_builder"]
+                if platform?('oracle')
+                  options ['--enablerepo=ol9_codeready_builder']
                 else
                   options('--enablerepo=crb')
                 end

--- a/libraries/sql/_connection.rb
+++ b/libraries/sql/_connection.rb
@@ -90,7 +90,12 @@ module PostgreSQL
               declare_resource(:package, libpq_package_name) { compile_time(true) }
               declare_resource(:package, 'perl-IPC-Run') do
                 compile_time(true)
-                options('--enablerepo=crb')
+                case node['platform']
+                when 'oracle'
+                  options ["--enablerepo=ol9_codeready_builder"]
+                else
+                  options('--enablerepo=crb')
+                end
               end
             end
           end

--- a/libraries/sql/_connection.rb
+++ b/libraries/sql/_connection.rb
@@ -84,7 +84,11 @@ module PostgreSQL
               declare_resource(:package, libpq_package_name) { compile_time(true) }
               declare_resource(:package, 'perl-IPC-Run') do
                 compile_time(true)
-                options('--enablerepo=powertools')
+                if platform?('oracle')
+                  options ['--enablerepo=ol8_codeready_builder']
+                else
+                  options('--enablerepo=powertools')
+                end
               end
             when 9
               declare_resource(:package, libpq_package_name) { compile_time(true) }


### PR DESCRIPTION
# Description

When using a newer Chef than exists in docker, installation of package `perl-IPC-run` (required to build the `pg` gem) fails on oracle linux 9. For example, kitchen suite `access-14-oraclelinux-9` fails to converge without this patch with error:

```
       Recipe: <Dynamically Defined Resource>
         * dnf_package[libpq5] action install
           - install version 0:16.4-42PGDG.rhel9.x86_64 of package libpq5
         * dnf_package[perl-IPC-Run] action install
           * No candidate version available for perl-IPC-Run
           ================================================================================
           Error executing action `install` on resource 'dnf_package[perl-IPC-Run]'
           ================================================================================

           Chef::Exceptions::Package
           -------------------------
           No candidate version available for perl-IPC-Run

           Cookbook Trace: (most recent call first)
           ----------------------------------------
           /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/_connection.rb:91:in `install_pg_gem'
           /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/_connection.rb:122:in `pg_client'
           /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/_connection.rb:182:in `execute_sql_params'
           /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/role.rb:46:in `pg_role?'
           /opt/kitchen/cache/cookbooks/postgresql/resources/role.rb:87:in `block in class_from_file'

           Resource Declaration:
           ---------------------
           # In /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/_connection.rb

            91:               declare_resource(:package, 'perl-IPC-Run') do
            92:                 compile_time(true)
            93:                 options('--enablerepo=crb')
            94:               end
            95:             end

           Compiled Resource:
           ------------------
           # Declared in /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/_connection.rb:91:in `install_pg_gem'

           dnf_package("perl-IPC-Run") do
             package_name "perl-IPC-Run"
             action [:install]
             default_guard_interpreter :default
             declared_type :package
             flush_cache {:before=>false, :after=>false}
             compile_time true
             options ["--enablerepo=crb"]
           end

           System Info:
           ------------
           chef_version=18.5.0
           platform=oracle
           platform_version=9.4
           ruby=ruby 3.1.4p223 (2023-03-30 revision 957bb7cb81) [x86_64-linux]
           program_name=/opt/cinc/bin/cinc-client
           executable=/opt/cinc/bin/cinc-client


         ================================================================================
         Error executing action `create` on resource 'postgresql_user[sous_chef]'
         ================================================================================

         Chef::Exceptions::Package
         -------------------------
         dnf_package[perl-IPC-Run] (/opt/kitchen/cache/cookbooks/postgresql/libraries/sql/_connection.rb line 91) had an error: Chef::Exceptions::Package: No candidate version available for perl-IPC-Run

         Cookbook Trace: (most recent call first)
         ----------------------------------------
         /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/_connection.rb:91:in `install_pg_gem'
         /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/_connection.rb:122:in `pg_client'
         /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/_connection.rb:182:in `execute_sql_params'
         /opt/kitchen/cache/cookbooks/postgresql/libraries/sql/role.rb:46:in `pg_role?'
         /opt/kitchen/cache/cookbooks/postgresql/resources/role.rb:87:in `block in class_from_file'

         Resource Declaration:
         ---------------------
         suppressed sensitive resource output

         Compiled Resource:
         ------------------
         suppressed sensitive resource output

         System Info:
         ------------
         chef_version=18.5.0
         platform=oracle
         platform_version=9.4
         ruby=ruby 3.1.4p223 (2023-03-30 revision 957bb7cb81) [x86_64-linux]
         program_name=/opt/cinc/bin/cinc-client
         executable=/opt/cinc/bin/cinc-client
```

Technically it still fails with this patch, because newer Chef doesn't have MD2 compiled into the embedded openssl (since [3263a96](https://github.com/chef/omnibus-software/commit/3263a96dc393186a0850499c2b3b622850c9a9f0)), which the system-provided `libldap.so.2` expects because it is present in the system openssl. That is being addressed in [RHEL-59715](https://issues.redhat.com/browse/RHEL-59715), and installing a patched `openldap` package after create but prior to verifying does result in success.

To work around the lack of a newer Chef in docker, I'm using the following environment variables in this branch with cinc workstation 24.8.1068:
```
CHEF_IMAGE=cincproject/cinc
CHEF_BINARY=/opt/cinc/bin/cinc-client
CHEF_VERSION=18.5.0
```

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
