### PR TITLE
Allow more fine-grained control over yum repo config. Fixes #716.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in the last 3 major versions of the postg
 ## Unreleased
 
 - Cast `server_config` keys to strings in `postgresql_config` to avoid unnecessary converges
+- Add `setup_pgdg_*` properties to `postgresql_install` to allow more fine grained control over derived `yum_repository` resources
 
 ## 12.0.3 - *2024-12-30*
 

--- a/documentation/postgresql_install.md
+++ b/documentation/postgresql_install.md
@@ -17,25 +17,30 @@
 
 ## Properties
 
-| Name                               | Name? | Type            | Default | Description                                      | Allowed Values |
-| ---------------------------------- | ----- | --------------- | ------- | ------------------------------------------------ | -------------- |
-| `sensitive`                        |       | true, false     |         |                                                  |                |
-| `version`                          |       | String, Integer |         | Version to install                               |                |
-| `source`                           |       | String, Symbol  |         | Installation source                              | repo, os       |
-| `client_packages`                  |       | String, Array   |         | Client packages to install                       |                |
-| `server_packages`                  |       | String, Array   |         | Server packages to install                       |                |
-| `repo_pgdg`                        |       | true, false     |         | Create pgdg repo                                 |                |
-| `repo_pgdg_common`                 |       | true, false     |         | Create pgdg-common repo                          |                |
-| `repo_pgdg_source`                 |       | true, false     |         | Create pgdg-source repo                          |                |
-| `repo_pgdg_updates_testing`        |       | true, false     |         | Create pgdg-updates-testing repo                 |                |
-| `repo_pgdg_source_updates_testing` |       | true, false     |         | Create pgdg-source-updates-testing repo          |                |
-| `yum_gpg_key_uri`                  |       | String          |         | YUM/DNF GPG key URL                              |                |
-| `apt_repository_uri`               |       | String          |         | apt repository URL                               |                |
-| `apt_gpg_key_uri`                  |       | String          |         | apt GPG key URL                                  |                |
-| `initdb_additional_options`        |       | String          |         | Additional options to pass to the initdb command |                |
-| `initdb_locale`                    |       | String          |         | Locale to use for the initdb command             |                |
-| `initdb_encoding`                  |       | String          |         | Encoding to use for the initdb command           |                |
-| `initdb_user`                      |       | String          |         | User to run the initdb command as                |                |
+| Name                               | Name? | Type            | Default           | Description                                      | Allowed Values |
+| ---------------------------------- | ----- | --------------- | ----------------- | ------------------------------------------------ | -------------- |
+| `sensitive`                        |       | true, false     | `true`            |                                                  |                |
+| `version`                          |       | String, Integer | `'17'`            | Version to install                               |                |
+| `source`                           |       | String, Symbol  | `:repo`           | Installation source                              | repo, os       |
+| `client_packages`                  |       | String, Array   | platform specific | Client packages to install                       |                |
+| `server_packages`                  |       | String, Array   | platform specific | Server packages to install                       |                |
+| `repo_pgdg`                        |       | true, false     | `true`            | Create pgdg repo                                 |                |
+| `setup_repo_pgdg`                  |       | true, false     | value of previous | Whether or not to manage the pgdg repo           |                |
+| `repo_pgdg_common`                 |       | true, false     | `true`            | Create pgdg-common repo                          |                |
+| `setup_repo_pgdg_common`           |       | true, false     | value of previous | Whether or not to manage the pgdg_common repo    |                |
+| `repo_pgdg_source`                 |       | true, false     | `false`           | Create pgdg-source repo                          |                |
+| `setup_repo_pgdg_source`           |       | true, false     | value of previous | Whether or not to manage the pgdg_source repo    |                |
+| `repo_pgdg_updates_testing`        |       | true, false     | `false`           | Create pgdg-updates-testing repo                 |                |
+| `setup_repo_pgdg_updates_testing`  |       | true, false     | value of previous | Whether or not to manage the pgdg_updates_testing repo |          |
+| `repo_pgdg_source_updates_testing` |       | true, false     | `false`           | Create pgdg-source-updates-testing repo          |                |
+| `setup_repo_pgdg_source_updates_testing` | | true, false     | value of previous | Whether or not to manage the pgdg_source_updates_testing repo |   |
+| `yum_gpg_key_uri`                  |       | String          | platform specific | YUM/DNF GPG key URL                              |                |
+| `apt_repository_uri`               |       | String          | https://download.postgresql.org/pub/repos/apt/ | apt repository URL  |                |
+| `apt_gpg_key_uri`                  |       | String          | https://download.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt GPG key URL |        |
+| `initdb_additional_options`        |       | String          |                   | Additional options to pass to the initdb command |                |
+| `initdb_locale`                    |       | String          |                   | Locale to use for the initdb command             |                |
+| `initdb_encoding`                  |       | String          |                   | Encoding to use for the initdb command           |                |
+| `initdb_user`                      |       | String          | `'postgres'`      | User to run the initdb command as                |                |
 
 ## Libraries
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -246,3 +246,25 @@ suites:
         pg_ver: "15"
     run_list:
       - recipe[test::server_install]
+  - name: all_repos_install_15
+    attributes:
+      test:
+        pg_ver: "15"
+    verifier:
+      inspec_tests:
+        - path: test/integration/all_repos_install/
+      inputs:
+        pg_ver: "15"
+    run_list:
+      - recipe[test::all_repos_install]
+  - name: no_repos_install_15
+    attributes:
+      test:
+        pg_ver: "15"
+    verifier:
+      inspec_tests:
+        - path: test/integration/no_repos_install/
+      inputs:
+        pg_ver: "15"
+    run_list:
+      - recipe[test::no_repos_install]

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -45,23 +45,43 @@ property :server_packages, [String, Array],
 
 property :repo_pgdg, [true, false],
           default: true,
-          description: 'Create pgdg repo'
+          description: 'Enable pgdg repo'
+
+property :setup_repo_pgdg, [true, false],
+          default: lazy { |r| r.repo_pgdg },
+          description: 'Setup pgdg repo. Defaults to value of `:repo_pgdg`.'
 
 property :repo_pgdg_common, [true, false],
           default: true,
-          description: 'Create pgdg-common repo'
+          description: 'Enable pgdg-common repo'
+
+property :setup_repo_pgdg_common, [true, false],
+          default: lazy { |r| r.repo_pgdg_common },
+          description: 'Setup pgdg-common repo. Defaults to value of `:repo_pgdg_common`.'
 
 property :repo_pgdg_source, [true, false],
           default: false,
-          description: 'Create pgdg-source repo'
+          description: 'Enable pgdg-source repo'
+
+property :setup_repo_pgdg_source, [true, false],
+          default: lazy { |r| r.repo_pgdg_source },
+          description: 'Setup pgdg-source repo. Defaults to value of `:repo_pgdg_source`.'
 
 property :repo_pgdg_updates_testing, [true, false],
           default: false,
-          description: 'Create pgdg-updates-testing repo'
+          description: 'Enable pgdg-updates-testing repo'
+
+property :setup_repo_pgdg_updates_testing, [true, false],
+          default: lazy { |r| r.repo_pgdg_updates_testing },
+          description: 'Setup pgdg-updates-testing repo. Defaults to value of `:repo_pgdg_updates_testing`.'
 
 property :repo_pgdg_source_updates_testing, [true, false],
           default: false,
-          description: 'Create pgdg-source-updates-testing repo'
+          description: 'Enable pgdg-source-updates-testing repo'
+
+property :setup_repo_pgdg_source_updates_testing, [true, false],
+          default: lazy { |r| r.repo_pgdg_source_updates_testing },
+          description: 'Setup pgdg-source-updates-testing repo. Defaults to value of `:repo_pgdg_source_updates_testing`.'
 
 property :yum_gpg_key_uri, String,
           default: lazy { default_yum_gpg_key_uri },
@@ -116,6 +136,7 @@ action_class do
         gpgcheck true
         gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
+        only_if { new_resource.repo_pgdg || new_resource.setup_repo_pgdg }
       end
 
       yum_repository 'PostgreSQL - common' do
@@ -126,6 +147,7 @@ action_class do
         gpgcheck true
         gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
+        only_if { new_resource.repo_pgdg_common || new_resource.setup_repo_pgdg_common }
       end
 
       yum_repository "PostgreSQL #{new_resource.version} - source " do
@@ -137,6 +159,7 @@ action_class do
         gpgcheck true
         gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
+        only_if { new_resource.repo_pgdg_source || new_resource.setup_repo_pgdg_source }
       end
 
       yum_repository "PostgreSQL #{new_resource.version} - updates testing" do
@@ -148,6 +171,7 @@ action_class do
         gpgcheck true
         gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
+        only_if { new_resource.repo_pgdg_updates_testing || new_resource.setup_repo_pgdg_updates_testing }
       end
 
       yum_repository "PostgreSQL #{new_resource.version} - source - updates testing" do
@@ -159,6 +183,7 @@ action_class do
         gpgcheck true
         gpgkey 'file:///etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY'
         action repo_action
+        only_if { new_resource.repo_pgdg_source_updates_testing || new_resource.setup_repo_pgdg_source_updates_testing }
       end
 
     when 'debian'

--- a/test/cookbooks/test/recipes/all_repos_install.rb
+++ b/test/cookbooks/test/recipes/all_repos_install.rb
@@ -1,0 +1,42 @@
+postgresql_install 'postgresql' do
+  version node['test']['pg_ver']
+  setup_repo_pgdg_source true
+  setup_repo_pgdg_updates_testing true
+  setup_repo_pgdg_source_updates_testing true
+  action %i(install init_server)
+end
+
+postgresql_config 'postgresql-server' do
+  version '15'
+
+  server_config({
+    'max_connections' => 110,
+    'shared_buffers' => '128MB',
+    'dynamic_shared_memory_type' => 'posix',
+    'max_wal_size' => '1GB',
+    'min_wal_size' => '80MB',
+    'log_destination' => 'stderr',
+    'logging_collector' => true,
+    'log_directory' => 'log',
+    'log_filename' => 'postgresql-%a.log',
+    'log_rotation_age' => '1d',
+    'log_rotation_size' => 0,
+    'log_truncate_on_rotation' => true,
+    'log_line_prefix' => '%m [%p]',
+    'log_timezone' => 'Etc/UTC',
+    'datestyle' => 'iso, mdy',
+    'timezone' => 'Etc/UTC',
+    'lc_messages' => 'C',
+    'lc_monetary' => 'C',
+    'lc_numeric' => 'C',
+    'lc_time' => 'C',
+    'default_text_search_config' => 'pg_catalog.english',
+  })
+
+  notifies :restart, 'postgresql_service[postgresql]', :delayed
+  action :create
+end
+
+postgresql_service 'postgresql' do
+  action %i(enable start)
+end

--- a/test/cookbooks/test/recipes/no_repos_install.rb
+++ b/test/cookbooks/test/recipes/no_repos_install.rb
@@ -1,0 +1,52 @@
+# I can do it myself!
+yum_repository 'postgresql-15' do
+  baseurl 'https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-$releasever-$basearch'
+  gpgkey "https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL#{node['platform_version'].to_i.eql?(7) ? '7' : ''}"
+end
+
+yum_repository 'postgresql-common' do
+  baseurl 'https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-$releasever-$basearch'
+  gpgkey "https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL#{node['platform_version'].to_i.eql?(7) ? '7' : ''}"
+end
+
+postgresql_install 'postgresql' do
+  version node['test']['pg_ver']
+  repo_pgdg false
+  repo_pgdg_common false
+  action %i(install init_server)
+end
+
+postgresql_config 'postgresql-server' do
+  version '15'
+
+  server_config({
+    'max_connections' => 110,
+    'shared_buffers' => '128MB',
+    'dynamic_shared_memory_type' => 'posix',
+    'max_wal_size' => '1GB',
+    'min_wal_size' => '80MB',
+    'log_destination' => 'stderr',
+    'logging_collector' => true,
+    'log_directory' => 'log',
+    'log_filename' => 'postgresql-%a.log',
+    'log_rotation_age' => '1d',
+    'log_rotation_size' => 0,
+    'log_truncate_on_rotation' => true,
+    'log_line_prefix' => '%m [%p]',
+    'log_timezone' => 'Etc/UTC',
+    'datestyle' => 'iso, mdy',
+    'timezone' => 'Etc/UTC',
+    'lc_messages' => 'C',
+    'lc_monetary' => 'C',
+    'lc_numeric' => 'C',
+    'lc_time' => 'C',
+    'default_text_search_config' => 'pg_catalog.english',
+  })
+
+  notifies :restart, 'postgresql_service[postgresql]', :delayed
+  action :create
+end
+
+postgresql_service 'postgresql' do
+  action %i(enable start)
+end

--- a/test/integration/all_repos_install/controls/all_repos_spec.rb
+++ b/test/integration/all_repos_install/controls/all_repos_spec.rb
@@ -15,7 +15,7 @@ if os[:family] == 'redhat'
   end
   %W(pgdg#{pg_ver}-source pgdg#{pg_ver}-updates-testing pgdg#{pg_ver}-source-updates-testing).each do |r|
     describe yum.repo(r) do
-      it { should_not exist }
+      it { should exist }
       it { should_not be_enabled }
     end
   end

--- a/test/integration/all_repos_install/inspec.yml
+++ b/test/integration/all_repos_install/inspec.yml
@@ -1,0 +1,13 @@
+---
+name: all_repos_install
+title: PostgreSQL server with all repos setup but only pgdg and pgdg-common enabled
+maintainer: Sous Chefs
+copyright_email: help@sous-chefs.org
+license: Apache
+summary: Verify the correct installation of the postgresql server including correct repos setup and enabled
+version: 0.0.1
+supports:
+  - os-family: unix
+depends:
+  - name: client
+    path: ./test/integration/client_install

--- a/test/integration/no_repos_install/controls/no_repos_spec.rb
+++ b/test/integration/no_repos_install/controls/no_repos_spec.rb
@@ -9,8 +9,8 @@ if os[:family] == 'redhat'
   end
   %W(pgdg#{pg_ver} pgdg-common).each do |r|
     describe yum.repo(r) do
-      it { should exist }
-      it { should be_enabled }
+      it { should_not exist }
+      it { should_not be_enabled }
     end
   end
   %W(pgdg#{pg_ver}-source pgdg#{pg_ver}-updates-testing pgdg#{pg_ver}-source-updates-testing).each do |r|

--- a/test/integration/no_repos_install/inspec.yml
+++ b/test/integration/no_repos_install/inspec.yml
@@ -1,0 +1,13 @@
+---
+name: no_repos_install
+title: PostgreSQL no_repos_install
+maintainer: Sous Chefs
+copyright_email: help@sous-chefs.org
+license: Apache
+summary: Verify the correct installation of the postgresql server with cookbook provided yum repos instead of resource
+version: 0.0.1
+supports:
+  - os-family: unix
+depends:
+  - name: client
+    path: ./test/integration/client_install

--- a/test/integration/no_repos_install/no_repos_spec.rb
+++ b/test/integration/no_repos_install/no_repos_spec.rb
@@ -15,7 +15,7 @@ if os[:family] == 'redhat'
   end
   %W(pgdg#{pg_ver}-source pgdg#{pg_ver}-updates-testing pgdg#{pg_ver}-source-updates-testing).each do |r|
     describe yum.repo(r) do
-      it { should_not exist }
+      it { should exist }
       it { should_not be_enabled }
     end
   end


### PR DESCRIPTION
# Description

Give users of `postgresql_install` more control over the derived `yum_repository` resources.

## Issues Resolved

#716 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
