### PR TITLE
Correct typo of createdb column

### DIFF
--- a/resources/role.rb
+++ b/resources/role.rb
@@ -90,7 +90,7 @@ load_current_value do |new_resource|
 
   rolename(role_data.fetch('rolname', nil))
   superuser(role_data.fetch('rolsuper', nil))
-  createdb(role_data.fetch('rolecreatedb', nil))
+  createdb(role_data.fetch('rolcreatedb', nil))
   createrole(role_data.fetch('rolcreaterole', nil))
   inherit(role_data.fetch('rolinherit', nil))
   login(role_data.fetch('rolcanlogin', nil))


### PR DESCRIPTION
# Description
There was a typo in the createdb field. It was checking for field `rolecreatedb` which doesn't exist. The correct field is `rolcreatedb`. 

Link to PostgreSQL docs: https://www.postgresql.org/docs/18/view-pg-roles.html
I checked previous versions and it hasn't changed in the past.

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
