### PR TITLE
Use --platform ruby to ensure we install the source based pg gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,11 @@ jobs:
     strategy:
       matrix:
         os:
+          - "almalinux-8"
           - "almalinux-9"
+          - "rockylinux-8"
           - "rockylinux-9"
+          - "oraclelinux-8"
           - "oraclelinux-9"
           - "centos-stream-9"
           - "amazonlinux-2023"
@@ -50,8 +53,6 @@ jobs:
           - "initdb-locale-17"
           - "server-install-os"
         exclude:
-          - os: "centos-7"
-            suite: "server-install-os"
           - os: "amazonlinux-2023"
             suite: "access-15"
           - os: "amazonlinux-2023"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
+- Use `--platform ruby` to ensure we install the source based pg gem
+
 ## 12.3.1 - *2025-07-17*
 
 - Correct createdb column name from `rolecreatedb` to `rolcreatedb`

--- a/libraries/sql/_connection.rb
+++ b/libraries/sql/_connection.rb
@@ -56,9 +56,9 @@ module PostgreSQL
         def pg_gem_build_options
           case node['platform_family']
           when 'rhel', 'amazon'
-            "-- --with-pg-include=#{postgresql_devel_path('include')} --with-pg-lib=#{postgresql_devel_path('lib')}"
+            "--platform ruby -- --with-pg-include=#{postgresql_devel_path('include')} --with-pg-lib=#{postgresql_devel_path('lib')}"
           when 'debian'
-            "-- --with-pg-include=#{postgresql_devel_path} --with-pg-lib=#{postgresql_devel_path}"
+            "--platform ruby -- --with-pg-include=#{postgresql_devel_path} --with-pg-lib=#{postgresql_devel_path}"
           else
             raise "Unsupported platform family #{node['platform_family']}"
           end


### PR DESCRIPTION
The upstream pg ruby gem has started including pre-complied pg gems which do not
work on EL8 due to the fact they were compiled on an Ubuntu platform that has a
newer glibc.

By using `--platform ruby` [1], this will force the installation using the
source which is what this cookbook expects.

In addition, make sure we test on EL8.

[1] https://github.com/ged/ruby-pg?tab=readme-ov-file#source-gem

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
