### PR TITLE
Ensure access config file is written before notifications are sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ## Unreleased
 
-Standardise files with files in sous-chefs/repo-management
+- Ensure access config file is written before notifications are sent
+- Standardise files with files in sous-chefs/repo-management
 
 ## 12.3.3 - *2025-09-04*
 

--- a/resources/access.rb
+++ b/resources/access.rb
@@ -95,6 +95,9 @@ action :create do
     else
       run_action(:update)
     end
+
+    # Ensure config file is written before notifications are sent
+    config_resource.run_action(:create)
   end
 end
 


### PR DESCRIPTION
If you use the postgresql_access resource and have it trigger a reload of the
postgresql_service resource, it will not do it in the correct order. Currently,
it will reload the server, and then the config file gets updated which means the
new config is never reloaded.

This ensures that it happens at the end of the resource run so it works in the
proper order.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
