### PR TITLE
fix(drop database): fix drop db regression

### DIFF
--- a/libraries/sql/database.rb
+++ b/libraries/sql/database.rb
@@ -76,7 +76,7 @@ module PostgreSQL
                          )
                        end
 
-          if properties.any? { |p| property_is_set?(p) }
+          if properties&.any? { |p| property_is_set?(p) }
             sql.push('WITH')
 
             properties.each do |p|

--- a/test/cookbooks/test/recipes/ident.rb
+++ b/test/cookbooks/test/recipes/ident.rb
@@ -95,4 +95,15 @@ postgresql_database 'test2' do
   action :delete
 end
 
+execute 'createdb "Test3"' do
+  user 'postgres'
+  creates '/tmp/Test3_created'
+end
+
+file '/tmp/Test3_created'
+postgresql_database 'drop Test3' do
+  database 'Test3'
+  action :delete
+end
+
 postgresql_extension 'plpgsql'


### PR DESCRIPTION
With the last bugfix a regression was introduced regarding query properties of the drop database action.

fix: any? on nil error when dropping a database

Properties where always nil, therefor `properties.any?` raises a error.

Ive noticed that there arent many tests regarding dropping a database. Added a create/drop of the same database with the `postgresql_database` resources. We also verify if the drop was succesful (capital sensitive).

# Description

we use the safe navigation operator so that any? can be called on a nil value, the statement will evaluate to false and skip the properties block.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [x] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [x] New functionality includes testing
- [x] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
