### PR TITLE
fix(role): preserve SCRAM password verifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in the last 3 major versions of the postgresql cookbook.
 
+## Unreleased
+
+### Bug Fixes
+
+* Preserve pre-computed SCRAM-SHA-256 role password verifiers
+
 ## [13.0.4](https://github.com/sous-chefs/postgresql/compare/v13.0.3...v13.0.4) (2026-04-07)
 
 

--- a/documentation/postgresql_install.md
+++ b/documentation/postgresql_install.md
@@ -17,30 +17,30 @@
 
 ## Properties
 
-| Name                               | Name? | Type            | Default           | Description                                      | Allowed Values |
-| ---------------------------------- | ----- | --------------- | ----------------- | ------------------------------------------------ | -------------- |
-| `sensitive`                        |       | true, false     | `true`            |                                                  |                |
-| `version`                          |       | String, Integer | `'17'`            | Version to install                               |                |
-| `source`                           |       | String, Symbol  | `:repo`           | Installation source                              | repo, os       |
-| `client_packages`                  |       | String, Array   | platform specific | Client packages to install                       |                |
-| `server_packages`                  |       | String, Array   | platform specific | Server packages to install                       |                |
-| `repo_pgdg`                        |       | true, false     | `true`            | Create pgdg repo                                 |                |
-| `setup_repo_pgdg`                  |       | true, false     | value of previous | Whether or not to manage the pgdg repo           |                |
-| `repo_pgdg_common`                 |       | true, false     | `true`            | Create pgdg-common repo                          |                |
-| `setup_repo_pgdg_common`           |       | true, false     | value of previous | Whether or not to manage the pgdg_common repo    |                |
-| `repo_pgdg_source`                 |       | true, false     | `false`           | Create pgdg-source repo                          |                |
-| `setup_repo_pgdg_source`           |       | true, false     | value of previous | Whether or not to manage the pgdg_source repo    |                |
-| `repo_pgdg_updates_testing`        |       | true, false     | `false`           | Create pgdg-updates-testing repo                 |                |
-| `setup_repo_pgdg_updates_testing`  |       | true, false     | value of previous | Whether or not to manage the pgdg_updates_testing repo |          |
-| `repo_pgdg_source_updates_testing` |       | true, false     | `false`           | Create pgdg-source-updates-testing repo          |                |
-| `setup_repo_pgdg_source_updates_testing` | | true, false     | value of previous | Whether or not to manage the pgdg_source_updates_testing repo |   |
-| `yum_gpg_key_uri`                  |       | String          | platform specific | YUM/DNF GPG key URL                              |                |
-| `apt_repository_uri`               |       | String          | [https://download.postgresql.org/pub/repos/apt/](https://download.postgresql.org/pub/repos/apt/) | apt repository URL  |                |
-| `apt_gpg_key_uri`                  |       | String          | [https://download.postgresql.org/pub/repos/apt/ACCC4CF8.asc](https://download.postgresql.org/pub/repos/apt/ACCC4CF8.asc) | apt GPG key URL |        |
-| `initdb_additional_options`        |       | String          |                   | Additional options to pass to the initdb command |                |
-| `initdb_locale`                    |       | String          |                   | Locale to use for the initdb command             |                |
-| `initdb_encoding`                  |       | String          |                   | Encoding to use for the initdb command           |                |
-| `initdb_user`                      |       | String          | `'postgres'`      | User to run the initdb command as                |                |
+| Name                                     | Name? | Type            | Default                                                                                                                  | Description                                                   | Allowed Values |
+| ---------------------------------------- | ----- | --------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | -------------- |
+| `sensitive`                              |       | true, false     | `true`                                                                                                                   |                                                               |                |
+| `version`                                |       | String, Integer | `'17'`                                                                                                                   | Version to install                                            |                |
+| `source`                                 |       | String, Symbol  | `:repo`                                                                                                                  | Installation source                                           | repo, os       |
+| `client_packages`                        |       | String, Array   | platform specific                                                                                                        | Client packages to install                                    |                |
+| `server_packages`                        |       | String, Array   | platform specific                                                                                                        | Server packages to install                                    |                |
+| `repo_pgdg`                              |       | true, false     | `true`                                                                                                                   | Create pgdg repo                                              |                |
+| `setup_repo_pgdg`                        |       | true, false     | value of previous                                                                                                        | Whether or not to manage the pgdg repo                        |                |
+| `repo_pgdg_common`                       |       | true, false     | `true`                                                                                                                   | Create pgdg-common repo                                       |                |
+| `setup_repo_pgdg_common`                 |       | true, false     | value of previous                                                                                                        | Whether or not to manage the pgdg_common repo                 |                |
+| `repo_pgdg_source`                       |       | true, false     | `false`                                                                                                                  | Create pgdg-source repo                                       |                |
+| `setup_repo_pgdg_source`                 |       | true, false     | value of previous                                                                                                        | Whether or not to manage the pgdg_source repo                 |                |
+| `repo_pgdg_updates_testing`              |       | true, false     | `false`                                                                                                                  | Create pgdg-updates-testing repo                              |                |
+| `setup_repo_pgdg_updates_testing`        |       | true, false     | value of previous                                                                                                        | Whether or not to manage the pgdg_updates_testing repo        |                |
+| `repo_pgdg_source_updates_testing`       |       | true, false     | `false`                                                                                                                  | Create pgdg-source-updates-testing repo                       |                |
+| `setup_repo_pgdg_source_updates_testing` |       | true, false     | value of previous                                                                                                        | Whether or not to manage the pgdg_source_updates_testing repo |                |
+| `yum_gpg_key_uri`                        |       | String          | platform specific                                                                                                        | YUM/DNF GPG key URL                                           |                |
+| `apt_repository_uri`                     |       | String          | [https://download.postgresql.org/pub/repos/apt/](https://download.postgresql.org/pub/repos/apt/)                         | apt repository URL                                            |                |
+| `apt_gpg_key_uri`                        |       | String          | [https://download.postgresql.org/pub/repos/apt/ACCC4CF8.asc](https://download.postgresql.org/pub/repos/apt/ACCC4CF8.asc) | apt GPG key URL                                               |                |
+| `initdb_additional_options`              |       | String          |                                                                                                                          | Additional options to pass to the initdb command              |                |
+| `initdb_locale`                          |       | String          |                                                                                                                          | Locale to use for the initdb command                          |                |
+| `initdb_encoding`                        |       | String          |                                                                                                                          | Encoding to use for the initdb command                        |                |
+| `initdb_user`                            |       | String          | `'postgres'`                                                                                                             | User to run the initdb command as                             |                |
 
 ## Libraries
 

--- a/documentation/postgresql_role.md
+++ b/documentation/postgresql_role.md
@@ -46,22 +46,25 @@
 
 ## Examples
 
-Create a user `user1` with a password, with `createdb` and set an expiration date to 2018, Dec 21.
+Create a user with a pre-computed SCRAM-SHA-256 verifier. Pass the verifier
+exactly as generated; shell escaping is not required.
 
 ```ruby
-postgresql_role 'user1' do
-  unencrypted_password 'UserP4ssword'
-  createdb true
-  valid_until '2018-12-31'
+postgresql_role 'secure_user' do
+  encrypted_password 'SCRAM-SHA-256$4096:27klCUc487uwvJVGKI5YNA==$6K2Y+S3YBlpfRNrLROoO2ulWmnrQoRlGI1GqpNRq0T0=:y4esBVjK/hMtxDB5aWN4ynS1SnQcT1TFTqV0J/snls4='
+  login true
 end
 ```
 
-Create a user `user1` with a password, with `createdb` and set an expiration date to 2018, Dec 21.
+The verifier is password-equivalent secret material and should be retrieved
+from an encrypted data bag, Chef Vault, or another secrets manager.
+
+Use the `set_password` action when rotating the verifier for an existing role.
 
 ```ruby
-postgresql_role 'user1' do
-  unencrypted_password 'UserP4ssword'
-  createdb true
-  valid_until '2018-12-31'
+postgresql_role 'secure_user password rotation' do
+  rolename 'secure_user'
+  encrypted_password lazy { ::File.read('/run/secrets/postgresql/secure_user').strip }
+  action :set_password
 end
 ```

--- a/libraries/access.rb
+++ b/libraries/access.rb
@@ -98,7 +98,7 @@ module PostgreSQL
 
           def to_s(sort: false)
             sort! if sort
-            @entries.map(&:to_s).join("\n")
+            @entries.join("\n")
           end
 
           def add(entry, position = nil)

--- a/libraries/ident.rb
+++ b/libraries/ident.rb
@@ -139,7 +139,7 @@ module PostgreSQL
 
           def to_s(sort: true)
             sort! if sort
-            @entries.map(&:to_s).join("\n")
+            @entries.join("\n")
           end
 
           def self.read(file = 'pg_ident.conf', sort: true)

--- a/libraries/sql/_connection.rb
+++ b/libraries/sql/_connection.rb
@@ -190,10 +190,10 @@ module PostgreSQL
         end
 
         def execute_sql(query, max_one_result: false)
-          Chef::Log.debug("Executing query: #{query}")
+          Chef::Log.debug('Executing PostgreSQL query')
           result = pg_client.exec(query).to_a
 
-          Chef::Log.debug("Got result: #{result}")
+          Chef::Log.debug("PostgreSQL query returned #{result.count} row(s)")
           return if result.empty?
 
           raise "Expected a single result, got #{result.count}" unless result.one? || !max_one_result
@@ -202,10 +202,10 @@ module PostgreSQL
         end
 
         def execute_sql_params(query, params, max_one_result: false)
-          Chef::Log.debug("Executing query: #{query} with params: #{params}")
+          Chef::Log.debug('Executing parameterized PostgreSQL query')
           result = pg_client.exec_params(query, params).to_a
 
-          Chef::Log.debug("Got result: #{result}")
+          Chef::Log.debug("PostgreSQL query returned #{result.count} row(s)")
           return if result.empty?
 
           raise "Expected a single result, got #{result.count}" unless result.one? || !max_one_result

--- a/libraries/sql/role.rb
+++ b/libraries/sql/role.rb
@@ -62,6 +62,16 @@ module PostgreSQL
           authid&.to_a&.pop&.fetch('rolpassword')
         end
 
+        def role_password_sql(new_resource)
+          if new_resource.encrypted_password
+            "ENCRYPTED PASSWORD #{pg_client.escape_literal(new_resource.encrypted_password)}"
+          elsif new_resource.unencrypted_password
+            "PASSWORD #{pg_client.escape_literal(new_resource.unencrypted_password)}"
+          else
+            'PASSWORD NULL'
+          end
+        end
+
         def role_sql(new_resource)
           sql = []
 
@@ -79,13 +89,7 @@ module PostgreSQL
 
           sql.push("CONNECTION LIMIT #{new_resource.connection_limit}")
 
-          if new_resource.encrypted_password
-            sql.push("ENCRYPTED PASSWORD '#{new_resource.encrypted_password}'")
-          elsif new_resource.unencrypted_password
-            sql.push("PASSWORD '#{new_resource.unencrypted_password}'")
-          else
-            sql.push('PASSWORD NULL')
-          end
+          sql.push(role_password_sql(new_resource))
 
           sql.push("VALID UNTIL '#{new_resource.valid_until}'") if new_resource.valid_until
 
@@ -120,13 +124,7 @@ module PostgreSQL
 
           sql.push("ALTER ROLE \"#{new_resource.rolename}\"")
 
-          if new_resource.encrypted_password
-            sql.push("ENCRYPTED PASSWORD '#{new_resource.encrypted_password}'")
-          elsif new_resource.unencrypted_password
-            sql.push("PASSWORD '#{new_resource.unencrypted_password}'")
-          else
-            sql.push('PASSWORD NULL')
-          end
+          sql.push(role_password_sql(new_resource))
 
           execute_sql("#{sql.join(' ').strip};")
         end

--- a/resources/role.rb
+++ b/resources/role.rb
@@ -59,6 +59,7 @@ property :unencrypted_password, String,
           description: 'Sets the role password via a plain text string'
 
 property :encrypted_password, String,
+          sensitive: true,
           description: 'Sets the role password via a pre-encrypted string'
 
 property :valid_until, String,

--- a/spec/libraries/role_spec.rb
+++ b/spec/libraries/role_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require_relative '../../libraries/sql/role'
+
+RSpec.describe PostgreSQL::Cookbook::SqlHelpers::Role do
+  subject(:helper) do
+    Class.new do
+      include PostgreSQL::Cookbook::SqlHelpers::Role
+    end.new
+  end
+
+  let(:pg_client) { double('PG::Connection') }
+
+  before do
+    allow(helper).to receive(:pg_client).and_return(pg_client)
+  end
+
+  describe '#role_password_sql' do
+    it 'quotes a SCRAM-SHA-256 verifier without modifying dollar signs' do
+      verifier = 'SCRAM-SHA-256$4096:salt$stored_key:server_key'
+      resource = double(encrypted_password: verifier, unencrypted_password: nil)
+
+      expect(pg_client).to receive(:escape_literal).with(verifier).and_return("'#{verifier}'")
+
+      expect(helper.send(:role_password_sql, resource)).to eq("ENCRYPTED PASSWORD '#{verifier}'")
+    end
+
+    it 'uses connection-aware quoting for a plaintext password' do
+      password = "don't interpolate me"
+      resource = double(encrypted_password: nil, unencrypted_password: password)
+
+      expect(pg_client).to receive(:escape_literal).with(password).and_return("'don''t interpolate me'")
+
+      expect(helper.send(:role_password_sql, resource)).to eq("PASSWORD 'don''t interpolate me'")
+    end
+
+    it 'clears the password when neither password property is set' do
+      resource = double(encrypted_password: nil, unencrypted_password: nil)
+
+      expect(helper.send(:role_password_sql, resource)).to eq('PASSWORD NULL')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -137,3 +137,8 @@ postgresql_access 'access with multiple databases' do
   address '127.0.0.1/32'
   auth_method 'scram-sha-256'
 end
+
+postgresql_user 'scram_test_user' do
+  encrypted_password 'SCRAM-SHA-256$4096:27klCUc487uwvJVGKI5YNA==$6K2Y+S3YBlpfRNrLROoO2ulWmnrQoRlGI1GqpNRq0T0=:y4esBVjK/hMtxDB5aWN4ynS1SnQcT1TFTqV0J/snls4='
+  login true
+end

--- a/test/integration/access/controls/base_access.rb
+++ b/test/integration/access/controls/base_access.rb
@@ -141,3 +141,14 @@ control 'postgresql-access-multiple-auth_options' do
     its('auth_params') { should cmp 'ldapbasedn="dc=example, dc=net" ldapsearchattribute=uid ldapserver=ldap.example.net' }
   end
 end
+
+control 'postgresql-role-preserves-scram-verifier' do
+  impact 1.0
+  desc 'The role resource stores a pre-computed SCRAM-SHA-256 verifier verbatim'
+
+  scram_verifier = 'SCRAM-SHA-256$4096:27klCUc487uwvJVGKI5YNA==$6K2Y+S3YBlpfRNrLROoO2ulWmnrQoRlGI1GqpNRq0T0=:y4esBVjK/hMtxDB5aWN4ynS1SnQcT1TFTqV0J/snls4='
+
+  describe pg_superuser_session.query("SELECT rolpassword FROM pg_authid WHERE rolname = 'scram_test_user';") do
+    its('output') { should eq scram_verifier }
+  end
+end


### PR DESCRIPTION
## Summary

- preserve pre-computed SCRAM-SHA-256 verifiers verbatim through the Ruby `pg` connection
- quote plaintext and encrypted password values with libpq's connection-aware literal escaping
- prevent password-bearing SQL and query results from being written to debug logs
- document creation and rotation semantics for encrypted role passwords
- remove the obsolete ChefSpec Berkshelf plugin required by the v9 lint workflow

## Testing

- `cookstyle .`
- `yamllint .`
- `markdownlint-cli2 '**/*.md'`
- RSpec: 67 examples, 0 failures
- `access-15-ubuntu-2404`: 36 successful, 0 failures
- `access-16-ubuntu-2404`: 36 successful, 0 failures
- `access-17-ubuntu-2404`: 36 successful, 0 failures
- `access-17-almalinux-9`: 36 successful, 0 failures

Closes #703.
Replaces #797, whose shell-specific dollar-sign escaping is no longer valid after the cookbook moved SQL execution to `PG::Connection`.
