### PR TITLE
fix: support pg under Habitat Chef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ### Bug Fixes
 
-* Use the pg gem's bundled libpq when Chef runs from Habitat
+* Use the pg gem's bundled libpq when Chef runs from Habitat, replacing incompatible source installs
 * Preserve pre-computed SCRAM-SHA-256 role password verifiers
 
 ## [13.0.5](https://github.com/sous-chefs/postgresql/compare/v13.0.4...v13.0.5) (2026-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in the last 3 major versions of the postg
 
 ### Bug Fixes
 
+* Use the pg gem's bundled libpq when Chef runs from Habitat
 * Preserve pre-computed SCRAM-SHA-256 role password verifiers
 
 ## [13.0.5](https://github.com/sous-chefs/postgresql/compare/v13.0.4...v13.0.5) (2026-07-30)

--- a/libraries/sql/_connection.rb
+++ b/libraries/sql/_connection.rb
@@ -17,6 +17,7 @@
 
 require_relative '../_utils'
 require_relative '../helpers'
+require 'rbconfig'
 
 module PostgreSQL
   module Cookbook
@@ -54,6 +55,8 @@ module PostgreSQL
         end
 
         def pg_gem_build_options
+          return if habitat_runtime?
+
           case node['platform_family']
           when 'rhel', 'amazon'
             "--platform ruby -- --with-pg-include=#{postgresql_devel_path('include')} --with-pg-lib=#{postgresql_devel_path('lib')}"
@@ -62,6 +65,10 @@ module PostgreSQL
           else
             raise "Unsupported platform family #{node['platform_family']}"
           end
+        end
+
+        def habitat_runtime?
+          ::RbConfig.ruby.start_with?('/hab/pkgs/')
         end
 
         def install_pg_gem
@@ -121,7 +128,7 @@ module PostgreSQL
 
           build_options = pg_gem_build_options
           declare_resource(:chef_gem, 'pg') do
-            options build_options
+            options build_options unless build_options.nil?
             version '~> 1.4'
             compile_time true
           end

--- a/libraries/sql/_connection.rb
+++ b/libraries/sql/_connection.rb
@@ -17,12 +17,21 @@
 
 require_relative '../_utils'
 require_relative '../helpers'
+require 'open3'
 require 'rbconfig'
 
 module PostgreSQL
   module Cookbook
     module SqlHelpers
       module Connection
+        PG_GEM_VERSION = '~> 1.4'.freeze
+        HABITAT_PG_GEM_CHECK = <<~RUBY.freeze
+          require 'rubygems'
+          gem 'pg', '#{PG_GEM_VERSION}'
+          require 'pg'
+          exit(Gem.loaded_specs.fetch('pg').platform.to_s == 'ruby' ? 1 : 0)
+        RUBY
+
         private
 
         include PostgreSQL::Cookbook::Utils
@@ -71,8 +80,34 @@ module PostgreSQL
           ::RbConfig.ruby.start_with?('/hab/pkgs/')
         end
 
+        def pg_gem_usable?
+          return gem_installed?('pg') unless habitat_runtime?
+          return true if @postgresql_habitat_pg_gem_usable
+          return false unless gem_installed?('pg')
+
+          # Keep a failed native extension load from activating the bad spec in Chef's process.
+          _, _, status = ::Open3.capture3(
+            {
+              'GEM_HOME' => ::Gem.dir,
+              'GEM_PATH' => ::Gem.path.join(::File::PATH_SEPARATOR),
+            },
+            ::RbConfig.ruby,
+            '-e',
+            HABITAT_PG_GEM_CHECK
+          )
+          @postgresql_habitat_pg_gem_usable = status.success?
+        end
+
         def install_pg_gem
-          return if gem_installed?('pg')
+          return if pg_gem_usable?
+
+          if habitat_runtime? && gem_installed?('pg')
+            declare_resource(:chef_gem, 'Remove incompatible pg gem') do
+              package_name 'pg'
+              compile_time true
+              action :remove
+            end
+          end
 
           libpq_package_name = case installed_postgresql_package_source
                                when :os
@@ -129,7 +164,7 @@ module PostgreSQL
           build_options = pg_gem_build_options
           declare_resource(:chef_gem, 'pg') do
             options build_options unless build_options.nil?
-            version '~> 1.4'
+            version PG_GEM_VERSION
             compile_time true
           end
         end
@@ -147,9 +182,9 @@ module PostgreSQL
         end
 
         def pg_client
-          install_pg_gem unless gem_installed?('pg')
+          install_pg_gem unless pg_gem_usable?
 
-          raise 'pg Gem Missing' unless gem_installed?('pg')
+          raise 'pg Gem Missing' unless pg_gem_usable?
 
           require 'pg' unless defined?(::PG)
 

--- a/spec/libraries/connection_spec.rb
+++ b/spec/libraries/connection_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'open3'
 require 'rbconfig'
 require_relative '../../libraries/sql/_connection'
 
@@ -55,7 +56,7 @@ RSpec.describe PostgreSQL::Cookbook::SqlHelpers::Connection do
           @properties = {}
         end
 
-        %i(compile_time options version).each do |property|
+        %i(action compile_time options package_name version).each do |property|
           define_method(property) { |value| @properties[property] = value }
         end
       end
@@ -84,6 +85,58 @@ RSpec.describe PostgreSQL::Cookbook::SqlHelpers::Connection do
           [:chef_gem, 'pg', { version: '~> 1.4', compile_time: true }],
         ]
       )
+    end
+
+    context 'when a prior converge installed an unusable pg gem under Habitat' do
+      let(:failed_status) { instance_double(Process::Status, success?: false) }
+
+      before do
+        allow(helper).to receive(:gem_installed?).with('pg').and_return(true)
+        allow(Open3).to receive(:capture3).and_return(['', '', failed_status])
+      end
+
+      it 'removes the incompatible gem before installing the platform gem' do
+        helper.send(:install_pg_gem)
+
+        expect(declared_resources).to eq(
+          [
+            [:chef_gem, 'Remove incompatible pg gem', { package_name: 'pg', compile_time: true, action: :remove }],
+            [:build_essential, 'Build Essential', { compile_time: true }],
+            [:package, 'libpq-dev', { compile_time: true }],
+            [:chef_gem, 'pg', { version: '~> 1.4', compile_time: true }],
+          ]
+        )
+      end
+    end
+
+    context 'when a healthy platform pg gem is already installed under Habitat' do
+      let(:successful_status) { instance_double(Process::Status, success?: true) }
+
+      before do
+        allow(helper).to receive(:gem_installed?).with('pg').and_return(true)
+        allow(Open3).to receive(:capture3).and_return(['', '', successful_status])
+      end
+
+      it 'does not disturb the installed gem' do
+        helper.send(:install_pg_gem)
+
+        expect(declared_resources).to be_empty
+      end
+    end
+
+    context 'when pg is already installed outside Habitat' do
+      before do
+        allow(RbConfig).to receive(:ruby).and_return('/opt/chef/embedded/bin/ruby')
+        allow(helper).to receive(:gem_installed?).with('pg').and_return(true)
+      end
+
+      it 'retains the existing presence-only behavior' do
+        expect(Open3).not_to receive(:capture3)
+
+        helper.send(:install_pg_gem)
+
+        expect(declared_resources).to be_empty
+      end
     end
   end
 end

--- a/spec/libraries/connection_spec.rb
+++ b/spec/libraries/connection_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+require 'rbconfig'
+require_relative '../../libraries/sql/_connection'
+
+RSpec.describe PostgreSQL::Cookbook::SqlHelpers::Connection do
+  subject(:helper) do
+    Class.new do
+      include PostgreSQL::Cookbook::SqlHelpers::Connection
+
+      attr_accessor :node
+    end.new
+  end
+
+  let(:node) { { 'platform_family' => 'debian' } }
+
+  before do
+    helper.node = node
+  end
+
+  describe '#pg_gem_build_options' do
+    before do
+      allow(helper).to receive(:postgresql_devel_path).and_return('/usr/include/postgresql')
+    end
+
+    context 'when Chef runs from a Habitat package' do
+      before do
+        allow(RbConfig).to receive(:ruby).and_return('/hab/pkgs/core/ruby3_4/3.4.8/20260514054813/bin/ruby')
+      end
+
+      it 'allows RubyGems to select the binary pg gem with bundled libpq' do
+        expect(helper.send(:pg_gem_build_options)).to be_nil
+      end
+    end
+
+    context 'when Chef does not run from a Habitat package' do
+      before do
+        allow(RbConfig).to receive(:ruby).and_return('/opt/chef/embedded/bin/ruby')
+      end
+
+      it 'retains the source pg gem build options' do
+        expect(helper.send(:pg_gem_build_options)).to eq(
+          '--platform ruby -- --with-pg-include=/usr/include/postgresql --with-pg-lib=/usr/include/postgresql'
+        )
+      end
+    end
+  end
+
+  describe '#install_pg_gem' do
+    let(:declared_resources) { [] }
+    let(:recording_resource) do
+      Class.new do
+        attr_reader :properties
+
+        def initialize
+          @properties = {}
+        end
+
+        %i(compile_time options version).each do |property|
+          define_method(property) { |value| @properties[property] = value }
+        end
+      end
+    end
+
+    before do
+      allow(RbConfig).to receive(:ruby).and_return('/hab/pkgs/core/ruby3_4/3.4.8/20260514054813/bin/ruby')
+      allow(helper).to receive(:gem_installed?).with('pg').and_return(false)
+      allow(helper).to receive(:installed_postgresql_package_source).and_return(:repo)
+      allow(helper).to receive(:platform_family?).with('rhel').and_return(false)
+      allow(helper).to receive(:postgresql_devel_pkg_name).and_return('libpq-dev')
+      allow(helper).to receive(:declare_resource) do |type, name, &block|
+        resource = recording_resource.new
+        resource.instance_eval(&block)
+        declared_resources << [type, name, resource.properties]
+      end
+    end
+
+    it 'does not force the source pg gem under Habitat' do
+      helper.send(:install_pg_gem)
+
+      expect(declared_resources).to eq(
+        [
+          [:build_essential, 'Build Essential', { compile_time: true }],
+          [:package, 'libpq-dev', { compile_time: true }],
+          [:chef_gem, 'pg', { version: '~> 1.4', compile_time: true }],
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Let RubyGems select the bundled-libpq `pg` platform gem when Chef runs from Habitat, while preserving source builds elsewhere.
- Validate existing Habitat pg installs out of process and replace ruby-platform or non-loadable gems left by an earlier converge.
- Leave healthy Habitat platform gems untouched and cover the shared `postgresql_user` / `postgresql_database` connection path.

Closes #833.

## Verification

- `cookstyle`: 52 files, 0 offenses.
- `env HOME=/private/tmp/postgresql-833-home CHEF_LICENSE=accept-no-persist chef exec rspec`: 73 examples, 0 failures.
- `env KITCHEN_LOCAL_YAML=kitchen.dokken.yml CHEF_LICENSE=accept-no-persist kitchen test access-16-ubuntu-2404`: Ubuntu 24.04 / PostgreSQL 16, 12 controls and 36 assertions passed, including second-converge idempotency.
- Exact Chef Infra Client 19.3.15 Habitat package: an isolated prior `pg-1.6.3` ruby-platform install was rejected, removed by the real `chef_gem` provider, replaced with `pg-1.6.3-aarch64-linux`, and loaded successfully.

## Risks / follow-ups

- The repository's Dokken/Omnibus provisioner cannot install Habitat-based Chef 19 (`chef/chef:19.3.15` is unavailable), so the exact Habitat package upgrade and Ubuntu 24.04 resource integration were validated separately.
- The pg binary gem does not support LDAP-based libpq connection-option lookup. Direct connection parameters and PostgreSQL HBA LDAP configuration are unaffected.
